### PR TITLE
Add simple setup.py file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # synbiohub_adapter
+
+## Installation
+
+`python setup.py install`

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+from setuptools import setup, find_packages
+
+setup(
+    name='sbh_adapter',
+    version='0.0.1',
+    packages=find_packages(),
+    install_requires=[
+        'SPARQLWrapper' #, sbol ?
+    ]
+)


### PR DESCRIPTION
Added a simple setup.py file make it easy to install for use in other projects, like xplan-api.

There is a problem with this, though, as it does not specify the missing sbol dependency (see issue #3). I'm not sure where that is supposed to come from.