### PR TITLE
Testing large upload to staging server

### DIFF
--- a/tests/Test_SBHSubmissions.py
+++ b/tests/Test_SBHSubmissions.py
@@ -118,6 +118,19 @@ class TestSBHSubmissions(unittest.TestCase):
 
 			sbhQuery.submit_Collection(sbh_connector, sbolDoc, True, 0)
 
+	def test_stress_large_file(self):
+
+		server = "https://hub-staging.sd2e.org/"
+		sbhQuery = SynBioHubQuery(server)
+
+		largeSbol = 'examples/c_trips100000.xml'
+		displayId = 'Design_100K'
+		name = '100K_Triples'
+		description = '100K Triple Upload'
+		version = '1'
+
+		sbolDoc = loadSBOLFile(largeSbol)
+		sbhQuery.submit_NewCollection(sbolDoc, displayId, name, description, version)
 
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
Staging server is throwing a 413 error, still:

```
python tests/Test_SBHSubmissions.py TestSBHSubmissions.test_stress_large_file
Enter SynBioHub Username: sd2_service@sd2e.org
Enter SynBioHub Password: 
{"status":413,"statusCode":413}
E
======================================================================
ERROR: test_stress_large_file (__main__.TestSBHSubmissions)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/Test_SBHSubmissions.py", line 133, in test_stress_large_file
    sbhQuery.submit_NewCollection(sbolDoc, displayId, name, description, version)
  File "/Users/markweston/Documents/Netrias/jenkins-integration/synbiohub_adapter/py3/lib/python3.6/site-packages/sbh_adapter-0.0.1-py3.6.egg/synbiohub_adapter/query_synbiohub.py", line 489, in submit_NewCollection
    self.submit_Collection(sbh_connector, sbolDoc, True, 0)
  File "/Users/markweston/Documents/Netrias/jenkins-integration/synbiohub_adapter/py3/lib/python3.6/site-packages/sbh_adapter-0.0.1-py3.6.egg/synbiohub_adapter/query_synbiohub.py", line 473, in submit_Collection
    sys.exit(0)
SystemExit: 0

----------------------------------------------------------------------
Ran 1 test in 1122.527s
```