### PR TITLE
Add SPARQL query and related HTTP call to retrieve plan intent stored as JSON

### DIFF
--- a/synbiohub_adapter/query_synbiohub.py
+++ b/synbiohub_adapter/query_synbiohub.py
@@ -770,7 +770,7 @@ class SynBioHubQuery(SBOLQuery):
 		return self.fetch_SPARQL(self._server, exp_set_size_query)
 
 	# Retrieves the attachments for a given plan URI
-	def query_plan_attachments(self, plan_uri):
+	def query_single_experiment_attachments(self, plan_uri):
 		attachment_query = """
 		SELECT ?attachment_id WHERE
 		{{

--- a/synbiohub_adapter/query_synbiohub.py
+++ b/synbiohub_adapter/query_synbiohub.py
@@ -769,6 +769,17 @@ class SynBioHubQuery(SBOLQuery):
 
 		return self.fetch_SPARQL(self._server, exp_set_size_query)
 
+	# Retrieves the attachments for a given plan URI
+	def query_plan_attachments(self, plan_uri):
+		attachment_query = """
+		SELECT ?attachment_id WHERE
+		{{
+		<{}> <http://wiki.synbiohub.org/wiki/Terms/synbiohub#attachment> ?attachment_id .
+		}}
+		""".format(plan_uri)
+
+		return self.fetch_SPARQL(self._server, attachment_query)
+
 	def query_synbiohub_statistics(self):
 		design_riboswitches = repr(len(self.query_design_riboswitches(pretty=True)))
 		exp_riboswitches = repr(len(self.query_experiment_riboswitches(by_sample=False)))

--- a/synbiohub_adapter/upload_sbol/upload_sbol.py
+++ b/synbiohub_adapter/upload_sbol/upload_sbol.py
@@ -67,6 +67,18 @@ class SynBioHub():
         print('attached file')
         print(response)
 
+    # for a given plan URI, retrieve its intent JSON
+    def get_plan_intent_attachment(self, plan_uri):
+
+        sbh_query = SynBioHubQuery(self.sparql)
+        attachments = sbh_query.query_plan_attachments(plan_uri)
+        for binding in attachments['results']['bindings']:
+            response = requests.get(binding['attachment_id']['value'] + '/download', headers={'Accept': 'text/plain', 'X-authorization': self.token})
+            attachment_json = response.json()
+            # TODO find a better way to identify intent attachments
+            if attachment_json.get("experimental-variables") != None:
+                return attachment_json
+
     def push_lab_plan_parameter(self, plan_uri, parameter_uri, parameter_value):
         """Pushes a lab parameter for a plan to SynBioHub.
 

--- a/synbiohub_adapter/upload_sbol/upload_sbol.py
+++ b/synbiohub_adapter/upload_sbol/upload_sbol.py
@@ -68,10 +68,10 @@ class SynBioHub():
         print(response)
 
     # for a given plan URI, retrieve its intent JSON
-    def get_plan_intent_attachment(self, plan_uri):
+    def get_single_experiment_intent_attachment(self, plan_uri):
 
         sbh_query = SynBioHubQuery(self.sparql)
-        attachments = sbh_query.query_plan_attachments(plan_uri)
+        attachments = sbh_query.query_single_experiment_attachments(plan_uri)
         for binding in attachments['results']['bindings']:
             response = requests.get(binding['attachment_id']['value'] + '/download', headers={'Accept': 'text/plain', 'X-authorization': self.token})
             attachment_json = response.json()

--- a/tests/Test_SPARQLQueries.py
+++ b/tests/Test_SPARQLQueries.py
@@ -397,6 +397,14 @@ class TestSBHQueries(unittest.TestCase):
 		exp_set_size = sbh_query.query_experiment_set_size(SD2Constants.RULE_30_EXPERIMENT_COLLECTION)
 		print(exp_set_size)
 
+	# Test attachment retrieval methods \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+	def test_query_plan_attachments(self):
+		sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
+		plan_attachments = sbh_query.query_plan_attachments("https://hub.sd2e.org/user/sd2e/experiment/biofab_yeast_gates_q0_aq_11269_1/1")
+		assert plan_attachments is not None and len(plan_attachments['results']['bindings']) == 1
+		print(plan_attachments)
+
 	# Test statistics query methods \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
 	def test_query_synbiohub_statistics(self):

--- a/tests/Test_SPARQLQueries.py
+++ b/tests/Test_SPARQLQueries.py
@@ -401,7 +401,7 @@ class TestSBHQueries(unittest.TestCase):
 
 	def test_query_plan_attachments(self):
 		sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
-		plan_attachments = sbh_query.query_plan_attachments("https://hub.sd2e.org/user/sd2e/experiment/biofab_yeast_gates_q0_aq_11269_1/1")
+		plan_attachments = sbh_query.query_single_experiment_attachments("https://hub.sd2e.org/user/sd2e/experiment/biofab_yeast_gates_q0_aq_11269_1/1")
 		assert plan_attachments is not None and len(plan_attachments['results']['bindings']) == 1
 		print(plan_attachments)
 


### PR DESCRIPTION
This a specific PR to wrap the retrieval of plan intent stored as JSON against a plan URI. Feedback on how to generalize this to other attachments (perhaps in the future? binary? images? other?) or alignment against current SBHA/upload_to_sbol.py standards would be welcome.

Tested locally per:
```
from synbiohub_adapter.upload_sbol import SynBioHub
sbh = SynBioHub(...)
sbh.get_plan_intent_attachment("https://hub.sd2e.org/user/sd2e/experiment/biofab_yeast_gates_q0_aq_11269_1/1")
{'controls': [{'design_name': 'UWBIOFAB_Scerevisiae_MATa/alpha'}], 'diagnostic-variables': [{'name': 'media_name', 'statistical-datatype': 'nominal'}, {'name': 'target_od', 'statistical-datatype': 'nominal'}], 'experimental-variables': [{'name': 'design_name', 'statistical-datatype': 'nominal'}], 'outcome-variables': [{'name': 'GFP', 'statistical-datatype': 'counts'}], 'search': {'sql': ['SELECT                                                   ', '   design_name                                           ', '   AVG(misbehaving_row) AS probability_surprising        ', '   FROM circuit_analysis_results                         ', '      GROUP BY                                           ', '           design_name                                   ', '           ORDER BY probability_surprising DESC          ']}, 'truth-table': {'input': [[0, 0], [0, 1], [1, 0], [1, 1]], 'input-variable-order': ['design_name'], 'mappings': {'design_name': {'UWBF_AND_00': [0, 0], 'UWBF_AND_01': [0, 1], 'UWBF_AND_10': [1, 0], 'UWBF_AND_11': [1, 1]}}, 'output': [0, 0, 0, 1], 'output-variable': 'GFP'}}
``` 