### PR TITLE
Add requests to requirements of the setup file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name='synbiohub_adapter',
     version='0.0.1',
     packages=find_packages(),
-    install_requires=['SPARQLWrapper', 'appdirs','pySBOLx==0.1', 'pysbol'],
+    install_requires=['SPARQLWrapper', 'appdirs', 'requests', 'pySBOLx==0.1', 'pysbol'],
     dependency_links=[
         'git+https://git@github.com/nroehner/pySBOLx.git#egg=pySBOLx-0.1'
     ]


### PR DESCRIPTION
The `requests` package is used on line 5 of `upload_sbol.py`, but requests is not installed as part of the setup. This results in an error at runtime.

This commit adds `requests` to the requirements.