### PR TITLE
Add attachment retrieval by name

### DIFF
--- a/synbiohub_adapter/query_synbiohub.py
+++ b/synbiohub_adapter/query_synbiohub.py
@@ -780,6 +780,18 @@ class SynBioHubQuery(SBOLQuery):
 
 		return self.fetch_SPARQL(self._server, attachment_query)
 
+	# Retrieves the named attachment for a given plan URI
+	def query_single_experiment_attachment(self, plan_uri, attachment_name):
+		attachment_name_query = """
+		SELECT ?attachment_id WHERE
+		{{
+		<{}> <http://wiki.synbiohub.org/wiki/Terms/synbiohub#attachment> ?attachment_id .
+		?attachment_id <http://purl.org/dc/terms/title> "{}" .
+		}}
+		""".format(plan_uri, attachment_name)
+
+		return self.fetch_SPARQL(self._server, attachment_name_query)
+
 	def query_synbiohub_statistics(self):
 		design_riboswitches = repr(len(self.query_design_riboswitches(pretty=True)))
 		exp_riboswitches = repr(len(self.query_experiment_riboswitches(by_sample=False)))

--- a/tests/Test_SPARQLQueries.py
+++ b/tests/Test_SPARQLQueries.py
@@ -405,6 +405,24 @@ class TestSBHQueries(unittest.TestCase):
 		assert plan_attachments is not None and len(plan_attachments['results']['bindings']) == 1
 		print(plan_attachments)
 
+		plan_attachments = sbh_query.query_single_experiment_attachments("foo")
+		assert plan_attachments is not None and len(plan_attachments['results']['bindings']) == 0
+		print(plan_attachments)
+
+	def test_query_plan_named_attachments(self):
+		sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
+		plan_attachments = sbh_query.query_single_experiment_attachment("https://hub.sd2e.org/user/sd2e/experiment/biofab_yeast_gates_q0_intent_control_test/1", "biofab_yg_UWBF_NOR_intent_control_test.json")
+		assert plan_attachments is not None and len(plan_attachments['results']['bindings']) == 1
+		print(plan_attachments)
+
+		plan_attachments = sbh_query.query_single_experiment_attachment("https://hub.sd2e.org/user/sd2e/experiment/biofab_yeast_gates_q0_intent_control_test/1", "biofab_yg_UWBF_NOR_intent_control_test_sample_attributes.json")
+		assert plan_attachments is not None and len(plan_attachments['results']['bindings']) == 1
+		print(plan_attachments)
+
+		plan_attachments = sbh_query.query_single_experiment_attachment("https://hub.sd2e.org/user/sd2e/experiment/biofab_yeast_gates_q0_intent_control_test/1", "foo")
+		assert plan_attachments is not None and len(plan_attachments['results']['bindings']) == 0
+		print(plan_attachments)
+
 	# Test statistics query methods \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
 	def test_query_synbiohub_statistics(self):


### PR DESCRIPTION
@nroehner @bjkeller 

This PR supports retrieving plan and sample attribute JSON files, linked through upload in the following PR:

https://github.com/SD2E/xplan_to_sbol/pull/7

An example below retrieves the plan JSON by name. It takes the plan_uri and attachment name as arguments.

This is generic and can retrieve other kinds of JSON attachments as well. Clean retrieval of other kinds of attachments (binary? image?) through this set of methods is not currently supported - it will blow up interpreting things as JSON. I'd prefer to keep this to limited and known plan / sample / intent JSON documents for now.

Test cases added for SPARQL queries.

```
>>> from synbiohub_adapter.upload_sbol import SynBioHub
INFO:rdflib:RDFLib Version: 4.2.2
>>> sbh = SynBioHub(...)
>>> sbh.get_single_experiment_attachment("https://hub.sd2e.org/user/sd2e/experiment/biofab_yeast_gates_q0_intent_control_test/1", "biofab_yg_UWBF_NOR_intent_control_test.json")
{'cost': 558.0, 'experiment_id' : ... }
>>> sbh.get_single_experiment_attachment("https://hub.sd2e.org/user/sd2e/experiment/biofab_yeast_gates_q0_intent_control_test/1", "foo")
No attachment found foo
```