### PR TITLE
Add a style check in unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /tests/__pycache__
 /synbiohub_adapter/__pycache__
 /sbh_adapter.egg-info
+*.pyc
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ python:
   - "3.6"
 install:
   - python setup.py install
+  - pip install pycodestyle
 script:
   - python -m unittest discover tests
+  - tests/checkstyle

--- a/tests/test_pycodestyle.py
+++ b/tests/test_pycodestyle.py
@@ -1,0 +1,49 @@
+
+import unittest
+
+# If this import fails, do `pip3 install [--user] pycodestyle`
+import pycodestyle
+
+# Please do not increase this number. Style warnings should DECREASE,
+# not increase.
+ALLOWED_ERRORS = 4137
+
+# Allow longer lines. The default is 79, which allows the 80th
+# character to be a line continuation symbol. Here, we increase the
+# line length to (effectively) 120.
+MAX_LINE_LENGTH = 119
+
+
+class TestStyle(unittest.TestCase):
+
+    def test_style(self):
+        """Run pycodestyle on the directory tree."""
+        # If there are files that don't have the '.py' extension, add
+        # them to dirs_and_files to include them in the style checks.
+        dirs_and_files = ['.']
+        # Allow 120 character lines. The default is 80, but that's a
+        # pretty narrow window size these days.
+        sg = pycodestyle.StyleGuide(quiet=True,
+                                    max_line_length=MAX_LINE_LENGTH)
+        report = sg.check_files(dirs_and_files)
+        self.assertEqual(report.total_errors, ALLOWED_ERRORS)
+
+    def test_clean(self):
+        """Ensure that warning free files stay that way.
+        """
+        # List all clean directories and files
+        # Keep these sorted
+        dirs_and_files = [
+            'build/lib/tests/__init__.py',
+            'setup.py',
+            'tests/__init__.py',
+            'tests/test_pycodestyle.py'
+        ]
+        sg = pycodestyle.StyleGuide(quiet=True,
+                                    max_line_length=MAX_LINE_LENGTH)
+        report = sg.check_files(dirs_and_files)
+        self.assertEqual(report.total_errors, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add a unit test that uses [pycodestyle](https://pypi.org/project/pycodestyle/) to check for style violations.

Start by allowing 4,137 errors, which is the current number for the codebase. The hope is that this will cap the number of allowed style errors at the current state. This number should be decreased as style warnings are eliminated over time.

There is a second test that verifies that files with no warnings stay that way. Currently there are only 4. The hope is that this number will increase over time as style warnings are eliminated.

Closes #60 