### PR TITLE
Fix test failure because queried object has been deleted from SBH

### DIFF
--- a/tests/test_pycodestyle.py
+++ b/tests/test_pycodestyle.py
@@ -6,7 +6,7 @@ import pycodestyle
 
 # Please do not increase this number. Style warnings should DECREASE,
 # not increase.
-ALLOWED_ERRORS = 2101
+ALLOWED_ERRORS = 2099
 
 # Allow longer lines. The default is 79, which allows the 80th
 # character to be a line continuation symbol. Here, we increase the

--- a/tests/test_sparql_queries.py
+++ b/tests/test_sparql_queries.py
@@ -689,7 +689,6 @@ class TestSBHQueries(unittest.TestCase):
             'https://hub.sd2e.org/user/sd2e/design/M9/1', 
             'https://hub.sd2e.org/user/sd2e/design/M90x20Kan0x20500x2Dug0x2Dper0x2DmL/1', 
             'https://hub.sd2e.org/user/sd2e/design/M90x20Chlor0x20350x2Dug0x2Dper0x2Dml0x20Kan0x20500x2Dug0x2Dper0x2Dml/1', 
-            'https://hub.sd2e.org/user/sd2e/design/SC0x20Media/1', 
             'https://hub.sd2e.org/user/sd2e/design/YEP0x2020x250x2Ddextrose/1', 
             'https://hub.sd2e.org/user/sd2e/design/M9_supplemented_no_carbon/1', 
             'https://hub.sd2e.org/user/sd2e/design/culture_media_2/1', 


### PR DESCRIPTION
This pull request resolves a test failure.  `test_query_design_media` was failing because it queried an object which had been deleted from SBH.  The target object was previously determined to be an empty, mostly unused copy of another object.  See https://gitlab.sd2e.org/sd2program/SD2-Librarian/issues/70