### PR TITLE
Fix sorts_query_result -> sort_query_result, add test coverage for strain circuits, input levels, and dictionary lookups.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,11 @@ WORKDIR /opt/scripts
 
 ADD . /opt/scripts
 
+# built-in pip is ancient
+RUN pip install --upgrade pip
+# nuke all existing packages in the image
+# ensure we only get the packages we want per the SBH setup.py
+RUN pip freeze | xargs pip uninstall -y || true
 RUN python3 setup.py install
 
 CMD python3 -m unittest discover /opt/scripts/tests

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name='synbiohub_adapter',
     version='0.0.1',
     packages=find_packages(),
-    install_requires=['SPARQLWrapper', 'appdirs', 'requests', 'pySBOLx==0.1', 'pysbol'],
+    install_requires=['pycodestyle==2.5.0', 'SPARQLWrapper', 'appdirs', 'requests', 'pySBOLx==0.1', 'pysbol'],
     dependency_links=[
         'git+https://git@github.com/nroehner/pySBOLx.git#egg=pySBOLx-0.1'
     ]

--- a/synbiohub_adapter/query_synbiohub.py
+++ b/synbiohub_adapter/query_synbiohub.py
@@ -244,7 +244,7 @@ class SynBioHubQuery(SBOLQuery):
             else:
                 query_result = self.format_query_result(query_result, ['gate', 'gate_type', 'input', 'level'])
         elif len(gates) == 1:
-            self.sorts_query_result(query_result, 'input')
+            self.sort_query_result(query_result, 'input')
 
         return query_result
 

--- a/tests/test_sparql_queries.py
+++ b/tests/test_sparql_queries.py
@@ -471,12 +471,54 @@ class TestSBHQueries(unittest.TestCase):
 
     ###########
 
-    # def test_query_gate_input_levels(self):
-    #   sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
-    #   input_levels1 = sbh_query.query_gate_input_levels(['https://hub.sd2e.org/user/sd2e/design/UWBF_16969/1'], True)
-    #   input_levels2 = sbh_query.query_gate_input_levels(['https://hub.sd2e.org/user/sd2e/design/UWBF_16969/1'], False)
-    #   print(input_levels1)
-    #   print(input_levels2)
+    def test_query_gate_logic(self):
+        sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
+        sbh_query.login(self.user, self.password)
+        actual_circuit = sbh_query.query_gate_logic(['https://hub.sd2e.org/user/sd2e/design/UWBF_16969/1'], pretty=True)
+        expected_circuit = [{'gate': 'https://hub.sd2e.org/user/sd2e/design/UWBF_16969/1',
+                             'gate_type': 'http://www.openmath.org/cd/logic1#xor'}]
+        assert expected_circuit == actual_circuit
+
+    def test_query_gate_input_levels(self):
+        sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
+        sbh_query.login(self.user, self.password)
+        input_levels = sbh_query.query_gate_input_levels(['https://hub.sd2e.org/user/sd2e/design/UWBF_16969/1'])
+        expected_levels_bindings = [{
+            'gate': {
+                'type': 'uri',
+                'value': 'https://hub.sd2e.org/user/sd2e/design/UWBF_16969/1'
+            },
+            'gate_type': {
+                'type': 'uri',
+                'value': 'http://www.openmath.org/cd/logic1#xor'
+            },
+            'input': {
+                'type': 'literal',
+                'value': 'pADH1:iRGR-r3'
+            },
+            'level': {
+                'type': 'literal',
+                'value': '0'
+            }
+        }, {
+            'gate': {
+                'type': 'uri',
+                'value': 'https://hub.sd2e.org/user/sd2e/design/UWBF_16969/1'
+            },
+            'gate_type': {
+                'type': 'uri',
+                'value': 'http://www.openmath.org/cd/logic1#xor'
+            },
+            'input': {
+                'type': 'literal',
+                'value': 'pGRR:RGR-r6'
+            },
+            'level': {
+                'type': 'literal',
+                'value': '1'
+            }
+        }]
+        assert expected_levels_bindings == input_levels["results"]["bindings"]
 
     def test_query_design_gates(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -1271,10 +1313,13 @@ class TestSBHQueries(unittest.TestCase):
 
     # # Test lab query methods \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
-    # def test_query_designs_by_lab_ids(self):
-    #   sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
-    #   designs = sbh_query.query_designs_by_lab_ids(SD2Constants.GINKGO, ['3411', '376', '772', '1993'])
-    #   print(designs)
+    def test_query_designs_by_lab_ids(self):
+        sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
+        sbh_query.login(self.user, self.password)
+        designs = sbh_query.query_designs_by_lab_ids(SD2Constants.GINKGO, ['1'], verbose=True)
+        expected_designs = {'1': {'identity': 'https://hub.sd2e.org/user/sd2e/design/CAT_G33_500/1',
+                            'name': 'Glycerol'}}
+        assert expected_designs == designs
 
     # Test statistics query methods \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 


### PR DESCRIPTION
Resolves: https://github.com/SD2E/synbiohub_adapter/issues/70

```
python -m unittest tests/test_sparql_queries.TestSBHQueries                              
Password: 
................................................
----------------------------------------------------------------------
Ran 48 tests in 33.042s

OK
```