### PR TITLE
Add version info to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,14 @@ setup(
     name='synbiohub_adapter',
     version='0.0.1',
     packages=find_packages(),
-    install_requires=['pycodestyle==2.5.0', 'SPARQLWrapper', 'appdirs', 'requests', 'pySBOLx==0.1', 'pysbol'],
+    install_requires=[
+        'SPARQLWrapper>=1.8.2',
+        'appdirs>=1.4.3',
+        'pySBOLx==0.1',
+        'pycodestyle>=2.5.0',
+        'pysbol==2.3.1.post6',
+        'requests>=2.21.0'
+    ],
     dependency_links=[
         'git+https://git@github.com/nroehner/pySBOLx.git#egg=pySBOLx-0.1'
     ]


### PR DESCRIPTION
Use '>=' for packages that are widely used, like requests and
SPARQLWrapper. Use '==' for pysbol so we don't pick up changes we
aren't expecting. Use '==' for pySBOLx because it is unversioned.

Closes #74 