### PR TITLE
Retry fetch_SPARQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ pip3 install --process-dependency-link .
 
 If you would like to install synbiohub_adapter so that changes to the
 source will be represented in the imported code without having to
-re-install, run one of the two commands below.
+re-install, run this command:
 
 ```
-pip3 install -e .
+pip3 install --process-dependency-link -e .
 ```
 
 ### Running Tests

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(
         'pySBOLx==0.1',
         'pycodestyle>=2.5.0',
         'pysbol==2.3.1.post6',
-        'requests>=2.21.0'
+        'requests>=2.21.0',
+        'tenacity>=5.0.3'
     ],
     dependency_links=[
         'git+https://git@github.com/nroehner/pySBOLx.git#egg=pySBOLx-0.1'


### PR DESCRIPTION
Use tenacity to retry fetch_SPARQL on error. The retry conditions are tunable. For now, retry 3 times, with a wait of 3 seconds between each retry.

This is hard to test under real conditions. For development I used `random` to introduce intermittent failures. The code seemed to work ok under those conditions.

Fixes #51 
