### PR TITLE
Add compatibility with pip 19

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 ## Installation
 
+_N.B. For pip versions 19 or higher, omit the `--process-dependency-links` argument._
+
+
 To install the current release of synbiohub_adapter:
 
 ```shell
@@ -16,7 +19,7 @@ pip3 install --process-dependency-links \
 You can also install from a git clone:
 
 ```shell
-pip3 install --process-dependency-link .
+pip3 install [--process-dependency-links] .
 ```
 
 ### Development Install
@@ -26,7 +29,7 @@ source will be represented in the imported code without having to
 re-install, run this command:
 
 ```
-pip3 install --process-dependency-link -e .
+pip3 install [--process-dependency-links] -e .
 ```
 
 ### Running Tests

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,35 @@
 #!/usr/bin/env python
 
+import pip
+from pkg_resources import parse_version
 from setuptools import setup, find_packages
+
+install_requires = [
+    'SPARQLWrapper>=1.8.2',
+    'appdirs>=1.4.3',
+    'pycodestyle>=2.5.0',
+    'pysbol==2.3.1.post6',
+    'requests>=2.21.0',
+    'tenacity>=5.0.3'
+]
+
+pip_version = parse_version(pip.__version__)
+if pip_version >= parse_version('19.0.0'):
+    # dependency specification changed in pip 19.0
+    dependency_links = []
+    install_requires.append('pysbolx @ git+https://git@github.com/nroehner/pySBOLx.git@master')
+else:
+    dependency_links = [
+        'git+https://git@github.com/nroehner/pySBOLx.git#egg=pySBOLx-0.1'
+    ]
+    install_requires.append('pySBOLx==0.1')
 
 setup(
     name='synbiohub_adapter',
     version='1.1',
     packages=find_packages(),
-    install_requires=[
-        'SPARQLWrapper>=1.8.2',
-        'appdirs>=1.4.3',
-        'pySBOLx==0.1',
-        'pycodestyle>=2.5.0',
-        'pysbol==2.3.1.post6',
-        'requests>=2.21.0',
-        'tenacity>=5.0.3'
-    ],
-    dependency_links=[
-        'git+https://git@github.com/nroehner/pySBOLx.git#egg=pySBOLx-0.1'
-    ],
+    install_requires=install_requires,
+    dependency_links=dependency_links,
     classifiers=[
         "Programming Language :: Python :: 3 :: Only"
     ]


### PR DESCRIPTION
pip 19 does not have the process-dependency-links flag. Detect pip 19
or higher and specify the dependency on pySBOLx appropriately.

Fixes #92 