### PR TITLE
Document lack of Python 2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,10 @@
 
 ## Installation
 
-_N.B. For pip versions 19 or higher, omit the `--process-dependency-links` argument._
-
-
 To install the current release of synbiohub_adapter:
 
 ```shell
-pip3 install --process-dependency-links \
-      git+https://github.com/SD2E/synbiohub_adapter.git@v1.1
+pip3 install git+https://github.com/SD2E/synbiohub_adapter.git@v1.1
 ```
 
 ### Install from git clone
@@ -19,7 +15,7 @@ pip3 install --process-dependency-links \
 You can also install from a git clone:
 
 ```shell
-pip3 install [--process-dependency-links] .
+pip3 install .
 ```
 
 ### Development Install
@@ -28,35 +24,36 @@ If you would like to install synbiohub_adapter so that changes to the
 source will be represented in the imported code without having to
 re-install, run this command:
 
-```
-pip3 install [--process-dependency-links] -e .
+```shell
+pip3 install -e .
 ```
 
 ### Running Tests
 
 Running tests requires the user provide a password for SynBioHub through the `SBH_PASSWORD` environment variable, e.g.
 
-```
+```shell
 SBH_PASSWORD=<pword> python3 -m unittest discover tests
 ```
 
 The tests include a check for conformance with Python style best-practices. If a new style violation is introduced into
 the code base, the test will fail. To diagnose this failure, run the following test:
 
-```
+```shell
 VERBOSE=1 python3 -m unittest tests/test_pycodestyle.py
 ```
 
 ### Linux Prerequisites
 
-On linux, you will to install `libxslt-dev` and `curl`.
+On linux, you will need to install `libxslt-dev` and `curl`.
 
-```
+```shell
 apt-get install curl libxslt-dev
 ```
 
 ### Using docker and docker-compose
 Run bash in docker container:
-```
+
+```shell
 docker-compose run --rm synbiohub_adapter bash
 ```

--- a/README.md
+++ b/README.md
@@ -48,14 +48,6 @@ the code base, the test will fail. To diagnose this failure, run the following t
 VERBOSE=1 python3 -m unittest tests/test_pycodestyle.py
 ```
 
-### Linux Prerequisites
-
-On linux, you will need to install `libxslt-dev` and `curl`.
-
-```shell
-apt-get install curl libxslt-dev
-```
-
 ### Using docker and docker-compose
 Run bash in docker container:
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 # synbiohub_adapter
 ![Build Status](https://api.travis-ci.com/SD2E/synbiohub_adapter.svg?branch=master)
 
+synbiohub_adapter is a Python 3 package that provides an API to [SynBioHub](http://wiki.synbiohub.org/wiki/Main_Page).
+
+synbiohub_adapter is not compatible with Python 2.
+
+
 ## Installation
 
 To install the current release of synbiohub_adapter:


### PR DESCRIPTION
Make it clear that synbiohub_adapter is not compatible with Python 2.

Closes #83