### PR TITLE
Add caltech lab constant

### DIFF
--- a/synbiohub_adapter/SynBioHubUtil.py
+++ b/synbiohub_adapter/SynBioHubUtil.py
@@ -65,6 +65,7 @@ class SD2Constants():
     YEAST_GATES_EXPERIMENT_COLLECTION = 'https://hub.sd2e.org/user/sd2e/experiment/yeast_gates/1'
 
     # SD2 labs
+    CALTECH = 'CalTech'
     GINKGO = 'Ginkgo'
     BIOFAB = 'BioFAB'
     TRANSCRIPTIC = 'Transcriptic'

--- a/tests/test_sparql_queries.py
+++ b/tests/test_sparql_queries.py
@@ -1386,9 +1386,14 @@ class TestSBHQueries(unittest.TestCase):
     def test_query_designs_by_lab_ids(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
         sbh_query.login(self.user, self.password)
+
         designs = sbh_query.query_designs_by_lab_ids(SD2Constants.GINKGO, ['1'], verbose=True)
         expected_designs = {'1': {'identity': 'https://hub.sd2e.org/user/sd2e/design/CAT_G33_500/1',
                             'name': 'Glycerol'}}
+
+        designs = sbh_query.query_designs_by_lab_ids(SD2Constants.CALTECH, ['a'], verbose=True)
+        expected_designs = {'a': {'identity': 'https://hub.sd2e.org/user/sd2e/design/Murray0x20BioCon0x20A/1',
+                            'name': 'Murray BioCon A'}}
         assert expected_designs == designs
 
     # Test statistics query methods \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\


### PR DESCRIPTION
Resolves: https://github.com/SD2E/synbiohub_adapter/issues/106

If the maintainers of this repository feel strong that "CalTech" should not be included under a class "SD2Constants", you might want to refactor the adapter to be more SD2 program/lab agnostic. As a user of this library, however, I have no issue with it.