### PR TITLE
Fix up style errors

### DIFF
--- a/synbiohub_adapter/SynBioHubUtil.py
+++ b/synbiohub_adapter/SynBioHubUtil.py
@@ -17,6 +17,8 @@ import tenacity
     author(s) : Nicholas Roehner
                 Tramy Nguyen
 '''
+
+
 class SBOLConstants():
     PRIMER = "http://identifiers.org/so/SO:0000112"
     RIBOSWITCH = "http://identifiers.org/so/SO:0000035"
@@ -44,10 +46,12 @@ class SBOLConstants():
     OM_NS = 'http://www.ontology-of-units-of-measure.org/resource/om-2#'
     BBN_HOMESPACE = "https://synbiohub.bbn.com"
 
+
 class BBNConstants():
     BBN_SERVER = "https://synbiohub.bbn.com/"
     BBN_YEASTGATES_COLLECTION = "https://synbiohub.bbn.com/user/tramyn/BBN_YEAST_GATES/BBN_YEAST_GATES_collection/1"
     BBN_RULE30_COLLECTION = 'https://synbiohub.bbn.com/user/tramyn/transcriptic_rule_30_q0_1_09242017/transcriptic_rule_30_q0_1_09242017_collection/1'
+
 
 class SD2Constants():
     SD2_SERVER = "https://hub.sd2e.org"
@@ -131,9 +135,12 @@ class SD2Constants():
 #     SD2_DESIGN_COLLECTION = 'https://hub.sd2e.org/user/sd2e/design/design_collection/1'
 #     SD2_EXPERIMENT_COLLECTION = 'https://hub.sd2e.org/user/sd2e/experiment/experiment_collection/1'
 
+
 class SBOLQuery():
     ''' This class structures SPARQL queries for objects belonging to classes from the SBOL data model.
-        An instance of this class will allow a user to pull information on these objects from the specified instance of SynBioHub.
+
+        An instance of this class will allow a user to pull information on these objects from the
+        specified instance of SynBioHub.
     '''
 
     # server: The SynBioHub server to call sparql queries on.
@@ -231,9 +238,10 @@ class SBOLQuery():
             """.format(ro=self.serialize_options(roles), el=entity_label, rl=role_label)
 
     def construct_custom_pattern(self, custom_properties, entity_label='entity'):
-        query_arr = ['?{el} {qn} {obj} .'.format(el=entity_label, qn=qname, obj=custom_properties[qname]) if custom_properties[qname].startswith('<') and custom_properties[qname].endswith('>')
-                     else '?{el} {qn} "{obj}" .'.format(el=entity_label, qn=qname, obj=custom_properties[qname]) for qname in custom_properties]
-
+        query_arr = ['?{el} {qn} {obj} .'.format(el=entity_label, qn=qname, obj=custom_properties[qname])
+                     if custom_properties[qname].startswith('<') and custom_properties[qname].endswith('>')
+                     else '?{el} {qn} "{obj}" .'.format(el=entity_label, qn=qname, obj=custom_properties[qname])
+                     for qname in custom_properties]
         return '\n'.join(query_arr)
 
     def construct_definition_pattern(self, definitions, entity_label='entity', sub_entity_label='sub_entity'):
@@ -247,7 +255,8 @@ class SBOLQuery():
             ?{el} sbol:definition ?{sel} .
             """.format(el=entity_label, sel=sub_entity_label, df=self.serialize_options(definitions))
 
-    def construct_sub_pattern(self, sub_entity_pattern="", definitions=[], entity_label='entity', sub_label='sub', sub_entity_label='sub_entity', rdf_type=None):
+    def construct_sub_pattern(self, sub_entity_pattern="", definitions=[], entity_label='entity', sub_label='sub',
+                              sub_entity_label='sub_entity', rdf_type=None):
         if rdf_type is None:
             sub_predicate = "(sbol:component) (sbol:functionalComponent) (sbol:module)"
         elif rdf_type == 'http://sbols.org/v2#ComponentDefinition':
@@ -328,13 +337,16 @@ class SBOLQuery():
         ?{el} rdf:type <{rt}> .
         """.format(el=entity_label, rt=rdf_type)
 
-    def construct_entity_pattern(self, types=[], roles=[], all_types=True, sub_entity_pattern="", definitions=[], entity_label='entity', other_entity_labels=[], type_label='type', role_label='role', sub_label='sub', sub_entity_label='sub_entity', rdf_type=None, custom_properties=[]):
+    def construct_entity_pattern(self, types=[], roles=[], all_types=True, sub_entity_pattern="", definitions=[],
+                                 entity_label='entity', other_entity_labels=[], type_label='type', role_label='role',
+                                 sub_label='sub', sub_entity_label='sub_entity', rdf_type=None, custom_properties=[]):
         if len(types) > 0 or len(roles) > 0 or len(sub_entity_pattern) > 0 or len(definitions) > 0 or rdf_type is not None:
             type_pattern = self.construct_type_pattern(types, all_types, entity_label, type_label)
 
             role_pattern = self.construct_role_pattern(roles, entity_label, role_label)
 
-            sub_pattern = self.construct_sub_pattern(sub_entity_pattern, definitions, entity_label, sub_label, sub_entity_label)
+            sub_pattern = self.construct_sub_pattern(sub_entity_pattern, definitions, entity_label, sub_label,
+                                                     sub_entity_label)
 
             if rdf_type is not None:
                 rdf_type_pattern = self.construct_rdf_type_pattern(rdf_type, entity_label)
@@ -377,11 +389,13 @@ class SBOLQuery():
             {qp}
             {fp}
             {cp}
-            """.format(tp=type_pattern, rp=role_pattern, sp=sub_pattern, rt=rdf_type_pattern, np=name_pattern, dp=description_pattern, qp=sequence_pattern, fp=feature_pattern, cp=custom_pattern)
+            """.format(tp=type_pattern, rp=role_pattern, sp=sub_pattern, rt=rdf_type_pattern, np=name_pattern,
+                       dp=description_pattern, qp=sequence_pattern, fp=feature_pattern, cp=custom_pattern)
         else:
             return ""
 
-    def construct_collection_pattern(self, collections=[], member_label='entity', members=[], member_cardinality='*', entity_label='entity', collection_label='collection'):
+    def construct_collection_pattern(self, collections=[], member_label='entity', members=[], member_cardinality='*',
+                                     entity_label='entity', collection_label='collection'):
         member_pattern_switcher = {
             'exp': self.construct_experiment_pattern
         }
@@ -400,20 +414,23 @@ class SBOLQuery():
                 VALUES (?{ml}) {{ {mem} }}
                 ?{cl} sbol:member ?{ml} .
                 {mp}
-                """.format(col=self.serialize_options(collections), cl=collection_label, mem=self.serialize_options(members), ml=member_label, mp=member_pattern)
+                """.format(col=self.serialize_options(collections), cl=collection_label,
+                           mem=self.serialize_options(members), ml=member_label, mp=member_pattern)
             else:
                 return """
                 VALUES (?{cl}) {{ {col} }}
                 ?{cl} sbol:member ?{ml} .
                 {mp}
-                """.format(col=self.serialize_options(collections), cl=collection_label, ml=member_label, mp=member_pattern)
+                """.format(col=self.serialize_options(collections), cl=collection_label, ml=member_label,
+                           mp=member_pattern)
         else:
             if len(members) > 0:
                 return """
                 VALUES (?{ml}) {{ {mem} }}
                 ?{cl} sbol:member ?{ml} .
                 {mp}
-                """.format(cl=collection_label, mem=self.serialize_options(members), ml=member_label, mp=member_pattern)
+                """.format(cl=collection_label, mem=self.serialize_options(members), ml=member_label,
+                           mp=member_pattern)
             else:
                 return """
                 ?{cl} sbol:member ?{ml} .
@@ -449,7 +466,11 @@ class SBOLQuery():
     # Constructs a SPARQL query for all members of the specified collection with
     # at least one of the specified types (or all of the specified types) and
     # at least one of the specified roles.
-    def construct_collection_entity_query(self, collections, member_label='entity', types=[], roles=[], all_types=True, sub_types=[], sub_roles=[], definitions=[], all_sub_types=True, entity_label=None, other_entity_labels=[], members=[], member_cardinality='+', rdf_type=None, entity_depth=1, custom_properties=[], sub_entity_label='sub_entity'):
+    def construct_collection_entity_query(self, collections, member_label='entity', types=[], roles=[],
+                                          all_types=True, sub_types=[], sub_roles=[], definitions=[],
+                                          all_sub_types=True, entity_label=None, other_entity_labels=[],
+                                          members=[], member_cardinality='+', rdf_type=None, entity_depth=1,
+                                          custom_properties=[], sub_entity_label='sub_entity'):
         target_labels = []
         if len(collections) > 1 or len(collections) == 0:
             target_labels.append('collection')
@@ -461,9 +482,15 @@ class SBOLQuery():
             target_labels.extend(other_entity_labels)
         target_labels.append(entity_label)
 
-        sub_entity_pattern = self.construct_entity_pattern(types=sub_types, roles=sub_roles, all_types=all_sub_types, entity_label=sub_entity_label, type_label='sub_type', role_label='sub_role')
-        entity_pattern_1 = self.construct_entity_pattern(types, roles, all_types, sub_entity_pattern, definitions, entity_label, other_entity_labels, sub_entity_label=sub_entity_label, rdf_type=rdf_type, custom_properties=custom_properties)
-        collection_pattern_1 = self.construct_collection_pattern(collections, member_label, members, member_cardinality, entity_label)
+        sub_entity_pattern = self.construct_entity_pattern(types=sub_types, roles=sub_roles, all_types=all_sub_types,
+                                                           entity_label=sub_entity_label, type_label='sub_type',
+                                                           role_label='sub_role')
+        entity_pattern_1 = self.construct_entity_pattern(types, roles, all_types, sub_entity_pattern,
+                                                         definitions, entity_label, other_entity_labels,
+                                                         sub_entity_label=sub_entity_label,
+                                                         rdf_type=rdf_type, custom_properties=custom_properties)
+        collection_pattern_1 = self.construct_collection_pattern(collections, member_label, members,
+                                                                 member_cardinality, entity_label)
 
         if entity_depth == 1:
             return """
@@ -478,11 +505,18 @@ class SBOLQuery():
             }}
             """.format(tl=' ?'.join(target_labels), cp1=collection_pattern_1, ep1=entity_pattern_1)
         elif entity_depth == 2:
-            sub_sub_entity_pattern = self.construct_entity_pattern(types=sub_types, roles=sub_roles, all_types=all_sub_types, entity_label=sub_entity_label, type_label='sub_type', role_label='sub_role')
-            sub_entity_pattern = self.construct_entity_pattern(types, roles, all_types, sub_sub_entity_pattern, definitions, entity_label, other_entity_labels, rdf_type=rdf_type, custom_properties=custom_properties)
-            entity_pattern_2 = self.construct_entity_pattern(sub_entity_pattern=sub_entity_pattern, sub_label='sub_prime', sub_entity_label=entity_label)
+            sub_sub_entity_pattern = self.construct_entity_pattern(types=sub_types, roles=sub_roles,
+                                                                   all_types=all_sub_types,
+                                                                   entity_label=sub_entity_label,
+                                                                   type_label='sub_type', role_label='sub_role')
+            sub_entity_pattern = self.construct_entity_pattern(types, roles, all_types, sub_sub_entity_pattern,
+                                                               definitions, entity_label, other_entity_labels,
+                                                               rdf_type=rdf_type, custom_properties=custom_properties)
+            entity_pattern_2 = self.construct_entity_pattern(sub_entity_pattern=sub_entity_pattern,
+                                                             sub_label='sub_prime', sub_entity_label=entity_label)
 
-            collection_pattern_2 = self.construct_collection_pattern(collections, member_label, members, member_cardinality)
+            collection_pattern_2 = self.construct_collection_pattern(collections, member_label, members,
+                                                                     member_cardinality)
 
             return """
             PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
@@ -497,7 +531,8 @@ class SBOLQuery():
                 {cp2}
                 {ep2}
             }} }}
-            """.format(tl=' ?'.join(target_labels), cp1=collection_pattern_1, cp2=collection_pattern_2, ep1=entity_pattern_1, ep2=entity_pattern_2)
+            """.format(tl=' ?'.join(target_labels), cp1=collection_pattern_1, cp2=collection_pattern_2,
+                       ep1=entity_pattern_1, ep2=entity_pattern_2)
         else:
             return ""
 
@@ -626,7 +661,8 @@ class SBOLQuery():
                         if sub_group_key not in formatted[entity_value]:
                             formatted[entity_value][sub_group_key] = {}
 
-                        self.__format_group(formatted[entity_value][sub_group_key], binding, sub_binding_keys, sub_group_key)
+                        self.__format_group(formatted[entity_value][sub_group_key], binding, sub_binding_keys,
+                                            sub_group_key)
 
         if sort_key is not None:
             self.sort_query_result(formatted, sort_key)
@@ -657,31 +693,51 @@ class SBOLQuery():
                 except:
                     query_list.sort()
 
-    def query_experiment_components(self, types=[], collections=[], comp_label='comp', other_comp_labels=[], trace_derivation=True, roles=[], all_types=True, sub_types=[], sub_roles=[], definitions=[], all_sub_types=True, experiments=[], custom_properties=[]):
+    def query_experiment_components(self, types=[], collections=[], comp_label='comp', other_comp_labels=[],
+                                    trace_derivation=True, roles=[], all_types=True, sub_types=[], sub_roles=[],
+                                    definitions=[], all_sub_types=True, experiments=[], custom_properties=[]):
         if trace_derivation:
             sample_cardinality = '*'
         else:
             sample_cardinality = ''
 
-        comp_query = self.construct_collection_entity_query(collections, 'exp', types, roles, all_types, sub_types, sub_roles, definitions, all_sub_types, comp_label, other_comp_labels, experiments, sample_cardinality, "http://sbols.org/v2#ComponentDefinition", 2, custom_properties)
+        comp_query = self.construct_collection_entity_query(collections, 'exp', types, roles, all_types, sub_types,
+                                                            sub_roles, definitions, all_sub_types, comp_label,
+                                                            other_comp_labels, experiments, sample_cardinality,
+                                                            "http://sbols.org/v2#ComponentDefinition", 2,
+                                                            custom_properties)
 
         return self.fetch_SPARQL(self._server, comp_query)
 
-    def query_experiment_modules(self, roles=[], collections=[], mod_label='mod', other_mod_labels=[], trace_derivation=True, sub_types=[], sub_roles=[], definitions=[], all_sub_types=True, experiments=[], custom_properties=[]):
+    def query_experiment_modules(self, roles=[], collections=[], mod_label='mod', other_mod_labels=[],
+                                 trace_derivation=True, sub_types=[], sub_roles=[], definitions=[],
+                                 all_sub_types=True, experiments=[], custom_properties=[]):
         if trace_derivation:
             sample_cardinality = '*'
         else:
             sample_cardinality = ''
 
-        mod_query = self.construct_collection_entity_query(collections, 'exp', roles=roles, sub_types=sub_types, sub_roles=sub_roles, definitions=definitions, all_sub_types=all_sub_types, entity_label=mod_label, other_entity_labels=other_mod_labels, members=experiments, member_cardinality=sample_cardinality, rdf_type="http://sbols.org/v2#ModuleDefinition", entity_depth=2, custom_properties=custom_properties)
+        mod_query = self.construct_collection_entity_query(collections, 'exp', roles=roles, sub_types=sub_types,
+                                                           sub_roles=sub_roles, definitions=definitions,
+                                                           all_sub_types=all_sub_types, entity_label=mod_label,
+                                                           other_entity_labels=other_mod_labels, members=experiments,
+                                                           member_cardinality=sample_cardinality,
+                                                           rdf_type="http://sbols.org/v2#ModuleDefinition",
+                                                           entity_depth=2, custom_properties=custom_properties)
 
         return self.fetch_SPARQL(self._server, mod_query)
 
     # Retrieves from the specified collection of design elements the URIs for all ComponentDefinitions with
     # at least one of the specified types (or all of the specified types) and at least one of the specified roles
     # This collection is typically associated with a challenge problem.
-    def query_design_components(self, types=[], collections=[], comp_label='comp', other_comp_labels=[], roles=[], all_types=True, sub_types=[], sub_roles=[], definitions=[], all_sub_types=True, custom_properties=[], members=[]):
-        comp_query = self.construct_collection_entity_query(collections, comp_label, types, roles, all_types, sub_types, sub_roles, definitions, all_sub_types, other_entity_labels=other_comp_labels, members=members, rdf_type="http://sbols.org/v2#ComponentDefinition", custom_properties=custom_properties)
+    def query_design_components(self, types=[], collections=[], comp_label='comp', other_comp_labels=[],
+                                roles=[], all_types=True, sub_types=[], sub_roles=[], definitions=[],
+                                all_sub_types=True, custom_properties=[], members=[]):
+        comp_query = self.construct_collection_entity_query(collections, comp_label, types, roles, all_types,
+                                                            sub_types, sub_roles, definitions, all_sub_types,
+                                                            other_entity_labels=other_comp_labels, members=members,
+                                                            rdf_type="http://sbols.org/v2#ComponentDefinition",
+                                                            custom_properties=custom_properties)
 
         return self.fetch_SPARQL(self._server, comp_query)
 
@@ -690,8 +746,16 @@ class SBOLQuery():
     # at least one of the specified sub-types (or all of the specified sub-types) and with
     # at least one of the specified roles.
     # This collection is typically associated with a challenge problem.
-    def query_design_modules(self, roles=[], collections=[], mod_label='mod', other_mod_labels=[], sub_types=[], sub_roles=[], definitions=[], all_sub_types=True, custom_properties=[], sub_comp_label='sub_comp', members=[]):
-        mod_query = self.construct_collection_entity_query(collections, mod_label, roles=roles, sub_types=sub_types, sub_roles=sub_roles, definitions=definitions, all_sub_types=all_sub_types, other_entity_labels=other_mod_labels, members=members, rdf_type="http://sbols.org/v2#ModuleDefinition", custom_properties=custom_properties, sub_entity_label=sub_comp_label)
+    def query_design_modules(self, roles=[], collections=[], mod_label='mod', other_mod_labels=[], sub_types=[],
+                             sub_roles=[], definitions=[], all_sub_types=True, custom_properties=[],
+                             sub_comp_label='sub_comp', members=[]):
+        mod_query = self.construct_collection_entity_query(collections, mod_label, roles=roles,
+                                                           sub_types=sub_types, sub_roles=sub_roles,
+                                                           definitions=definitions, all_sub_types=all_sub_types,
+                                                           other_entity_labels=other_mod_labels, members=members,
+                                                           rdf_type="http://sbols.org/v2#ModuleDefinition",
+                                                           custom_properties=custom_properties,
+                                                           sub_entity_label=sub_comp_label)
 
         return self.fetch_SPARQL(self._server, mod_query)
 
@@ -754,9 +818,13 @@ def login_SBH(server):
 def export_definitions_to_csv(server, collections, csv_path):
     sbol_query = SBOLQuery(server)
 
-    comps = sbol_query.format_query_result(sbol_query.query_design_components(collections=collections, other_comp_labels=['name']), ['comp', 'name'])
+    comps = sbol_query.format_query_result(sbol_query.query_design_components(collections=collections,
+                                                                              other_comp_labels=['name']),
+                                           ['comp', 'name'])
 
-    mods = sbol_query.format_query_result(sbol_query.query_design_modules(collections=collections, other_mod_labels=['name']), ['mod', 'name'])
+    mods = sbol_query.format_query_result(sbol_query.query_design_modules(collections=collections,
+                                                                          other_mod_labels=['name']),
+                                          ['mod', 'name'])
 
     with open(csv_path, 'w', newline='') as csv_file:
         csv_writer = csv.writer(csv_file, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)

--- a/synbiohub_adapter/upload_sbol/upload_sbol.py
+++ b/synbiohub_adapter/upload_sbol/upload_sbol.py
@@ -18,7 +18,8 @@ def main(args=None):
     parser.add_argument('-p', '--password')
     parser.add_argument('-u', '--url', nargs='?', default='https://hub.sd2e.org')
     parser.add_argument('-s', '--sparql', nargs='?', default='http://hub-api.sd2e.org:80/sparql')
-    parser.add_argument('-f', '--sbol_files', nargs='*', default=[f for f in os.listdir('.') if os.path.isfile(f) and f.endswith('.xml')])
+    parser.add_argument('-f', '--sbol_files', nargs='*',
+                        default=[f for f in os.listdir('.') if os.path.isfile(f) and f.endswith('.xml')])
     parser.add_argument('-w', '--overwrite', action='store_true')
     parser.add_argument('-W', '--overwrite_sub_collections', action='store_true')
     parser.add_argument('-c', '--collection_uri', nargs='?', default=None)
@@ -47,13 +48,18 @@ def main(args=None):
         sbh = SynBioHub(args.url, args.email, args.password, args.sparql)
 
         if args.collection_id is not None and args.collection_version is not None and args.collection_name is not None and args.collection_description is not None:
-            sbh.submit_collection(docs[0], args.collection_id, args.collection_version, args.collection_name, args.collection_description, int(args.max_upload))
+            sbh.submit_collection(docs[0], args.collection_id, args.collection_version, args.collection_name,
+                                  args.collection_description, int(args.max_upload))
         elif args.collection_uri is not None:
-            sbh.submit_to_collection(docs, args.collection_uri, int(args.max_upload), args.overwrite, args.overwrite_sub_collections, args.sub_collection_id, args.sub_collection_version, args.sub_collection_name, args.sub_collection_description)
+            sbh.submit_to_collection(docs, args.collection_uri, int(args.max_upload), args.overwrite,
+                                     args.overwrite_sub_collections, args.sub_collection_id,
+                                     args.sub_collection_version, args.sub_collection_name,
+                                     args.sub_collection_description)
         else:
             raise CollectionArgumentError()
     else:
         raise EmptySubmissionError()
+
 
 class SynBioHub():
     def __init__(self, url, email, password, sparql):
@@ -61,16 +67,21 @@ class SynBioHub():
         self.url = url
         self.part_shop = PartShop(url)
         self.part_shop.login(email, password)
-        response = requests.post(url + '/login', headers={'Accept': 'text/plain'}, data={'email': email, 'password': password})
+        response = requests.post(url + '/login',
+                                 headers={'Accept': 'text/plain'},
+                                 data={'email': email, 'password': password})
         self.token = response.content.decode('UTF-8')
         self.sparql = sparql
 
-    def submit_collection(self, doc, collection_id, collection_version, collection_name, collection_description, max_upload=0, sub_collection_id=None, sub_collection_version=None, sub_collection_name=None, sub_collection_description=None):
+    def submit_collection(self, doc, collection_id, collection_version, collection_name, collection_description,
+                          max_upload=0, sub_collection_id=None, sub_collection_version=None,
+                          sub_collection_name=None, sub_collection_description=None):
         if max_upload > 0 and len(doc) > max_upload:
             raise MaxUploadError(max_upload)
 
         if sub_collection_id is not None and sub_collection_version is not None:
-            self.__create_root_sub_collection(doc, sub_collection_id, sub_collection_version, sub_collection_name, sub_collection_description)
+            self.__create_root_sub_collection(doc, sub_collection_id, sub_collection_version, sub_collection_name,
+                                              sub_collection_description)
 
         doc.displayId = collection_id
         doc.name = collection_name
@@ -84,21 +95,28 @@ class SynBioHub():
         else:
             print(response)
 
-    def submit_to_collection(self, docs, collection_uri, max_upload=0, overwrite=False, overwrite_sub_collections=False, sub_collection_id=None, sub_collection_version=None, sub_collection_name=None, sub_collection_description=None):
+    def submit_to_collection(self, docs, collection_uri, max_upload=0, overwrite=False,
+                             overwrite_sub_collections=False, sub_collection_id=None, sub_collection_version=None,
+                             sub_collection_name=None, sub_collection_description=None):
         collection_namespace = self.__get_top_level_namespace(collection_uri)
 
         submission_docs = []
 
         for doc in docs:
             if max_upload > 0 and len(doc) > max_upload or len(self.__get_namespaces(doc)) > 1:
-                submission_docs = submission_docs + self.__split_document_by_namespace(doc, collection_namespace, max_upload)
+                submission_docs = submission_docs + self.__split_document_by_namespace(doc, collection_namespace,
+                                                                                       max_upload)
 
                 submission_docs = submission_docs + self.__create_sub_collection_documents(doc, collection_namespace)
             else:
                 submission_docs.append(doc)
 
         if sub_collection_id is not None and sub_collection_version is not None:
-            submission_docs.append(self.__create_root_sub_collection_document(docs, collection_namespace, sub_collection_id, sub_collection_version, sub_collection_name, sub_collection_description))
+            submission_docs.append(self.__create_root_sub_collection_document(docs, collection_namespace,
+                                                                              sub_collection_id,
+                                                                              sub_collection_version,
+                                                                              sub_collection_name,
+                                                                              sub_collection_description))
 
         if overwrite and not overwrite_sub_collections:
             self.__merge_remote_sub_collections(submission_docs, collection_namespace)
@@ -351,8 +369,11 @@ class SynBioHub():
         setHomespace(temp_homespace)
 
     @classmethod
-    def __create_root_sub_collection_document(cls, docs, collection_namespace, sub_collection_id, sub_collection_version, sub_collection_name=None, sub_collection_description=None):
-        root_sub_collection = cls.__create_sub_collection(sub_collection_id, sub_collection_version, sub_collection_name, sub_collection_description)
+    def __create_root_sub_collection_document(cls, docs, collection_namespace, sub_collection_id,
+                                              sub_collection_version, sub_collection_name=None,
+                                              sub_collection_description=None):
+        root_sub_collection = cls.__create_sub_collection(sub_collection_id, sub_collection_version,
+                                                          sub_collection_name, sub_collection_description)
 
         for doc in docs:
             remote_uri_arr = ['/'.join([collection_namespace] + obj.identity.split('/')[-2:]) for obj in doc]
@@ -366,8 +387,10 @@ class SynBioHub():
         return root_sub_collection_doc
 
     @classmethod
-    def __create_root_sub_collection(cls, doc, sub_collection_id, sub_collection_version, sub_collection_name=None, sub_collection_description=None):
-        root_sub_collection = cls.__create_sub_collection(sub_collection_id, sub_collection_version, sub_collection_name, sub_collection_description)
+    def __create_root_sub_collection(cls, doc, sub_collection_id, sub_collection_version, sub_collection_name=None,
+                                     sub_collection_description=None):
+        root_sub_collection = cls.__create_sub_collection(sub_collection_id, sub_collection_version,
+                                                          sub_collection_name, sub_collection_description)
 
         local_uri_arr = [obj.identity for obj in doc]
 
@@ -378,7 +401,8 @@ class SynBioHub():
         return root_sub_collection
 
     @classmethod
-    def __create_sub_collection(cls, sub_collection_id, sub_collection_version, sub_collection_name=None, sub_collection_description=None):
+    def __create_sub_collection(cls, sub_collection_id, sub_collection_version, sub_collection_name=None,
+                                sub_collection_description=None):
         sub_collection = Collection(sub_collection_id, sub_collection_version)
 
         if sub_collection_name is not None:
@@ -397,7 +421,10 @@ class SynBioHub():
             requests.get(uri + '/remove', headers=header)
 
     def attach_file(self, file, uri):
-        response = requests.post(uri + '/attach', headers={'Accept': 'text/plain', 'X-authorization': self.token}, files={'file': open(file, 'rb')})
+        response = requests.post(uri + '/attach',
+                                 headers={'Accept': 'text/plain',
+                                          'X-authorization': self.token},
+                                 files={'file': open(file, 'rb')})
 
         print(response)
 
@@ -414,7 +441,9 @@ class SynBioHub():
                 cut_i.append(i * cut_len)
             cut_i.append(cut_i[-1] + len(member_uris) % cut_len)
             for i in range(0, len(cut_i) - 1):
-                responses.append(sbh_query.query_collection_members(collection_uris, member_uris[cut_i[i]:cut_i[i + 1]], rdf_type))
+                responses.append(sbh_query.query_collection_members(collection_uris,
+                                                                    member_uris[cut_i[i]:cut_i[i + 1]],
+                                                                    rdf_type))
 
         collection_to_member = {}
 
@@ -440,7 +469,9 @@ class SynBioHub():
         attachments = sbh_query.query_single_experiment_attachment(plan_uri, attachment_name)
         if len(attachments['results']['bindings']) > 0:
             attachment_id = attachments['results']['bindings'][0]['attachment_id']['value']
-            response = requests.get(attachment_id + '/download', headers={'Accept': 'text/plain', 'X-authorization': self.token})
+            response = requests.get(attachment_id + '/download',
+                                    headers={'Accept': 'text/plain',
+                                             'X-authorization': self.token})
             return response.json()
         print("No attachment found {}".format(attachment_name))
 
@@ -450,7 +481,9 @@ class SynBioHub():
         attachments = sbh_query.query_single_experiment_attachments(plan_uri)
         for binding in attachments['results']['bindings']:
             attachment_id = binding['attachment_id']['value']
-            response = requests.get(attachment_id + '/download', headers={'Accept': 'text/plain', 'X-authorization': self.token})
+            response = requests.get(attachment_id + '/download',
+                                    headers={'Accept': 'text/plain',
+                                             'X-authorization': self.token})
             try:
                 attachment_json = response.json()
                 # TODO find a better way to identify intent attachments
@@ -472,7 +505,9 @@ class SynBioHub():
         except AssertionError:
             raise BadLabParameterError(parameter_uri)
 
-        if len(self.query_collection_members([plan_uri], [SD2Constants.SD2_EXPERIMENT_COLLECTION], 'http://sd2e.org#Experiment')) == 0:
+        if len(self.query_collection_members([plan_uri],
+                                             [SD2Constants.SD2_EXPERIMENT_COLLECTION],
+                                             'http://sd2e.org#Experiment')) == 0:
             raise UndefinedURIError(plan_uri)
 
         uri_arr = plan_uri.split('/')
@@ -534,13 +569,18 @@ class SynBioHub():
 
         print(response)
 
+
 class CollectionArgumentError(Exception):
 
     def __init__(self):
         pass
 
     def __str__(self):
-        return "Either the URI of an existing collection (-c) or the ID (-I), version (-V), name (-N), and description (-D) of a new collection must be provided as arguments."
+        msg = ("Either the URI of an existing collection (-c) or the ID (-I),"
+               " version (-V), name (-N), and description (-D) of a new"
+               " collection must be provided as arguments.")
+        return msg
+
 
 class EmptySubmissionError(Exception):
 
@@ -550,13 +590,16 @@ class EmptySubmissionError(Exception):
     def __str__(self):
         return "No documents were submitted for upload."
 
+
 class MaxUploadError(Exception):
 
     def __init__(self, max_upload):
         self.max_upload = max_upload
 
     def __str__(self):
-        return "Submitted document contains more objects than the max upload size of {max}".format(max=repr(self.max_upload))
+        msg = "Submitted document contains more objects than the max upload size of {max}"
+        return msg.format(max=repr(self.max_upload))
+
 
 class SubCollectionMergeError(Exception):
 
@@ -565,7 +608,9 @@ class SubCollectionMergeError(Exception):
         self.collection_version = collection_version
 
     def __str__(self):
-        return "Sub collection with ID {id} and version {ve} failed to merge.".format(id=self.collection_id, ve=self.collection_version)
+        msg = "Sub collection with ID {id} and version {ve} failed to merge."
+        return msg.format(id=self.collection_id, ve=self.collection_version)
+
 
 class MissingCollectionError(Exception):
 
@@ -575,6 +620,7 @@ class MissingCollectionError(Exception):
     def __str__(self):
         return "There is no Collection with URI {uri}.".format(uri=self.collection_uri)
 
+
 class DuplicateCollectionError(Exception):
 
     def __init__(self, collection_id, collection_version):
@@ -582,7 +628,9 @@ class DuplicateCollectionError(Exception):
         self.collection_version = collection_version
 
     def __str__(self):
-        return "There already exists a Collection with ID {id} and version {ve}.".format(id=self.collection_id, ve=self.collection_version)
+        msg = "There already exists a Collection with ID {id} and version {ve}."
+        return msg.format(id=self.collection_id, ve=self.collection_version)
+
 
 class ObjectMismatchError(Exception):
 
@@ -591,10 +639,13 @@ class ObjectMismatchError(Exception):
         self.obj_version = obj.version
 
     def __str__(self):
-        return "Target Collection already contains a non-matching object with ID {id} and version {ve}.".format(id=self.obj_id, ve=obj_version)
+        msg = "Target Collection already contains a non-matching object with ID {id} and version {ve}."
+        return msg.format(id=self.obj_id, ve=obj_version)
+
 
 class SBHLabParameterError(Exception):
     pass
+
 
 class BadLabParameterError(SBHLabParameterError):
 
@@ -603,6 +654,7 @@ class BadLabParameterError(SBHLabParameterError):
 
     def __str__(self):
         return "Invalid parameter URI: {}".format(self.parameter)
+
 
 class UndefinedURIError(SBHLabParameterError):
 

--- a/tests/DataGenerator.py
+++ b/tests/DataGenerator.py
@@ -4,6 +4,7 @@ import time
 from rdflib import Graph
 import re
 
+
 def get_uniqueID(idPrefix):
     t = time.ctime()
     uid = '_'.join([idPrefix, t])
@@ -14,6 +15,7 @@ def create_compDef(idPrefix):
     c_uri = get_uniqueID('compDef' + idPrefix)
     compDef = ComponentDefinition(c_uri, BIOPAX_DNA, '1.0')
     return compDef
+
 
 def create_seq(idPrefix):
     s_uri = get_uniqueID('seq' + idPrefix)

--- a/tests/SBHRun_Environment.py
+++ b/tests/SBHRun_Environment.py
@@ -18,7 +18,7 @@ from rdflib import Graph
 from synbiohub_adapter.SynBioHubUtil import *
 from sbol import *
 
-'''
+"""
     This class will perform unit testing to query information from SynBioHub's instances.
 
     Installation Requirement(s):
@@ -30,16 +30,17 @@ from sbol import *
     python -m tests.SBHRun_Environment
 
     author(s) :Tramy Nguyen
-'''
+"""
 
 
 class myThread (threading.Thread):
 
-    '''
+    """
     An instance of this class will allow a user to execute N numbers of pushes to a SynBioHub instance.
     sbolTriples: A list of SBOL Triples that stores SBOL documents
-    sbh_connector: An instance of pySBOL's PartShop needed to perform login for pushing and pulling data to and from SynBioHub
-    '''
+    sbh_connector: An instance of pySBOL's PartShop needed to perform login
+                   for pushing and pulling data to and from SynBioHub
+    """
     def __init__(self, sbolTriples, sbh_connector):
         threading.Thread.__init__(self)
         self.sbolTriples_list = sbolTriples
@@ -48,28 +49,29 @@ class myThread (threading.Thread):
         self.tupTime_List = []
         self.pushPull_List = []
 
-    '''
+    """
     A default run method that will run after a thread is created and started
-    '''
+    """
     def run(self):
         self.thread_start = time.clock()
         for sbolTriple in self.sbolTriples_list:
             push_time = push_sbh(sbolTriple.sbolDoc(), self.sbh_connector)
             self.tupTime_List.append((push_time, sbolTriple))
-            self.pushPull_List.append((push_time, 0))  # TODO: currently pull will not work on current pySBOL build so set to 0
+            # TODO: currently pull will not work on current pySBOL build so set to 0
+            self.pushPull_List.append((push_time, 0))
         self.thread_end = time.clock()
 
-    '''
+    """
     Returns the time (seconds) it took to run an instance of this thread
-    '''
+    """
     def thread_duration(self):
         return self.thread_end - self.thread_start
 
-    '''
+    """
     Returns a list of python triples where each Triples are structured as (t1, t2).
     t1 = Time it took for each push
     t2 = An instance of the SBOLTriple class that holds information about the given SBOL file.
-    '''
+    """
     def tripleTime_List(self):
         return self.tupTime_List
 
@@ -79,7 +81,7 @@ class myThread (threading.Thread):
 
 class SBOLTriple():
 
-    '''
+    """
     An instance of this class will allow a user to access 3 types of information about an SBOLDocument.
     1. the number of SBOL triples found in a SBOL document,
     2. the SBOL document object generated from pySBOL, and
@@ -87,7 +89,7 @@ class SBOLTriple():
 
     xmlFile: the full path of the SBOL File used to create the SBOL document
 
-    '''
+    """
     def __init__(self, xmlFile, uid):
         xmlGraph = Graph()
         xmlGraph.parse(xmlFile)
@@ -100,9 +102,9 @@ class SBOLTriple():
         self.__sbolDoc = self.create_sbolDoc(xmlFile, uid)
         self.__sbolFile = xmlFile
 
-    '''
+    """
     Returns a new SBOL document created from the given SBOL file and an instance of an SBOLTriple
-    '''
+    """
     def create_sbolDoc(self, sbolFile, uid):
         sbolDoc = Document()
         sbolDoc.read(sbolFile)
@@ -127,22 +129,20 @@ class SBOLTriple():
         return self.__tripleSize
 
 
-'''
-Generates a unique id
-'''
 def get_uniqueID(idPrefix):
+    """Generates a unique id
+    """
     t = time.ctime()
     uid = '_'.join([idPrefix, t])
     return re.sub(r'[: ]', '_', uid)
 
 
-'''
-Returns a list of SBOL Documents
-numDocs: An integer value to indicate how many SBOL documents this method should create
-idPrefix: A unique id prefix to set each SBOL document
-sbolFile: the SBOL file to create an SBOL document from
-'''
 def create_sbolDocs(numDocs, idPrefix, sbolFile):
+    """Returns a list of SBOL Documents
+    numDocs: An integer value to indicate how many SBOL documents this method should create
+    idPrefix: A unique id prefix to set each SBOL document
+    sbolFile: the SBOL file to create an SBOL document from
+    """
     sbolDoc_List = []
     sbolTriples = []
     u_counter = 0
@@ -156,31 +156,29 @@ def create_sbolDocs(numDocs, idPrefix, sbolFile):
     return sbolDoc_List, sbolTriples
 
 
-'''
-Returns the full path of a randomly selected SBOL file found in the given directory
-dirLocation: The directory to select a random SBOL file from
-'''
 def get_randomFile(sbolFiles):
+    """Returns the full path of a randomly selected SBOL file found in the given directory
+    dirLocation: The directory to select a random SBOL file from
+    """
     selectedFile = random.choice(sbolFiles)
     return selectedFile
 
 
-'''
-Returns a list of xml file found in the given directory
-'''
 def get_sbolList(dirLocation):
+    """Returns a list of xml file found in the given directory
+    """
     for root, dir, files in os.walk(dirLocation):
         sbolFiles = [os.path.abspath(os.path.join(root, fileName)) for fileName in files]
         return sbolFiles
 
 
-'''
-Returns the time (seconds) it takes to make a push to a new Collection on SynBioHub
-
-sbh_connector: An instance of pySBOL's PartShop needed to perform login for pushing and pulling data to and from SynBioHub
-sbolURI: The URI of the SynBioHub collection or the specific part to be fetched
-'''
 def push_sbh(sbolDoc, sbh_connector):
+    """Returns the time (seconds) it takes to make a push to a new Collection on SynBioHub
+
+    sbh_connector: An instance of pySBOL's PartShop needed to perform login
+                   for pushing and pulling data to and from SynBioHub
+    sbolURI: The URI of the SynBioHub collection or the specific part to be fetched
+    """
     start = time.clock()
     result = sbh_connector.submit(sbolDoc)
     end = time.clock()
@@ -190,13 +188,13 @@ def push_sbh(sbolDoc, sbh_connector):
     return end - start
 
 
-'''
-Returns the time (seconds) it takes to make a pull from an existing SynBioHub Collection
-
-sbh_connector: An instance of pySBOL's PartShop needed to perform login for pushing and pulling data to and from SynBioHub
-sbolURI: The URI of the SynBioHub collection or the specific part to be fetched
-'''
 def pull_sbh(sbh_connector, sbolURI):
+    """Returns the time (seconds) it takes to make a pull from an existing SynBioHub Collection
+
+    sbh_connector: An instance of pySBOL's PartShop needed to perform login
+                   for pushing and pulling data to and from SynBioHub
+    sbolURI: The URI of the SynBioHub collection or the specific part to be fetched
+    """
     sbolDoc = Document()
     setHomespace("https://bbn.com")
     start = time.clock()
@@ -251,6 +249,7 @@ def generate_speedData(sbolFile, sbh_connector, sbolDoc_size, idPrefix):
     # df.loc['Total'] = df.sum()
     return df
 
+
 def run_triples(sbh_connector, collPrefix, sbolFiles):
     triples_list = []
     doc = 0
@@ -295,6 +294,7 @@ def run_setThreads(sbh_connector, set_size, t_growthRate, sbolFile, sbolDoc_size
 
     return setId_List, threadId_List, threadDur_List
 
+
 def generate_setData(sbh_connector, iterations, set_size, t_growthRate, sbolFile, sbolDoc_size, collPrefix):
     runId_List = []
     setId_List = []
@@ -314,6 +314,7 @@ def generate_setData(sbh_connector, iterations, set_size, t_growthRate, sbolFile
                       columns=['Run_ID', 'Set_ID', 'Thread_ID', 'Time/Thread'])
     return df
 
+
 def generate_tripleData(sbh_connector, iterations, collPrefix, sbolFiles):
     runId_List = []
     tripeSize_List = []
@@ -331,10 +332,12 @@ def generate_tripleData(sbh_connector, iterations, collPrefix, sbolFiles):
                       columns=['Run_ID', 'Triple_Size', 'Push_Time'])
     return df
 
+
 def get_fileName(filePath):
     file_ext = os.path.basename(filePath)
     file_name, f_ext = os.path.splitext(file_ext)
     return file_name
+
 
 def br_speed(sbh_connector, sbolDoc_size, sbolFiles):
     for f in sbolFiles:
@@ -357,10 +360,12 @@ def br_setThread(sbh_connector, iterations, set_size, t_growthRate, sbolDoc_size
         create_SetBarPlot(df, iterations, set_size, f, trip_obj.totalTriples(), sbolDoc_size)
         df.to_csv("outputs/Set_f%s_iter%s_s%s_d%s.csv" % (fileName, iterations, set_size, sbolDoc_size))
 
+
 def br_triples(sbh_connector, iterations, sbolFiles):
     df = generate_tripleData(sbh_connector, iterations, "RT", sbolFiles)
     create_TripleScatterPlot(df, iterations)
     df.to_csv("outputs/Triples_iter%s.csv" % (iterations))
+
 
 def create_SpeedLinePlot(df, f, sbolDoc_size, trip_size):
     y_max = 20
@@ -374,6 +379,7 @@ def create_SpeedLinePlot(df, f, sbolDoc_size, trip_size):
 
     fileName = get_fileName(f)
     fig.savefig('outputs/SpeedResult_f%s_d%s.pdf' % (fileName, sbolDoc_size))
+
 
 def create_SpeedLine2Plot(df, f, sbolDoc_size, trip_size):
     fig, ax = plt.subplots()
@@ -404,6 +410,7 @@ def create_SetBarPlot(df, iterations, set_size, f, trip_size, doc_size):
     fileName = get_fileName(f)
     fig.savefig('outputs/Set_f%s_iter%s_s%s_d%s.pdf' % (fileName, iterations, set_size, doc_size))
 
+
 def create_TripleScatterPlot(df, iterations):
     fig, ax = plt.subplots()
     plt.ylim((0, 20))
@@ -417,6 +424,7 @@ def create_TripleScatterPlot(df, iterations):
     ax.set_ylabel("Time to Push (sec)")
     ax.set_xlabel("Document Size (# of Triples)")
     fig.savefig('outputs/Triples_iter%s.pdf' % (iterations))
+
 
 def backup_sequentialLoad():
     # At one point, update pushing to SBH to do something like this so performance doesn't suffer.
@@ -448,4 +456,5 @@ if __name__ == '__main__':
     # br_triples(sbh_connector, iterations, sbolFiles)
 
     # iterations, set_size=10, t_growthRate=5, sbolDoc_size=100
-    # br_setThread(sbh_connector, 3, 5, 3, 50, sbolFiles) # TODO: MAKE SURE TO CHANGE COLOR OF BAR GRAPH TO MAKE IT LOOK COOL...
+    # TODO: MAKE SURE TO CHANGE COLOR OF BAR GRAPH TO MAKE IT LOOK COOL...
+    # br_setThread(sbh_connector, 3, 5, 3, 50, sbolFiles)

--- a/tests/test_pycodestyle.py
+++ b/tests/test_pycodestyle.py
@@ -59,8 +59,7 @@ class TestStyle(unittest.TestCase):
             'tests/test_authentication.py',
             'tests/test_fallback_cache.py',
             'tests/test_pycodestyle.py',
-            'tests/test_sbh_submissions.py',
-            'tests/test_sbolquery.py'
+            'tests/test_sbh_submissions.py'
         ]
         sg = pycodestyle.StyleGuide(quiet=QUIET,
                                     max_line_length=MAX_LINE_LENGTH,

--- a/tests/test_pycodestyle.py
+++ b/tests/test_pycodestyle.py
@@ -6,7 +6,7 @@ import pycodestyle
 
 # Please do not increase this number. Style warnings should DECREASE,
 # not increase.
-ALLOWED_ERRORS = 365
+ALLOWED_ERRORS = 205
 
 # Allow longer lines. The default is 79, which allows the 80th
 # character to be a line continuation symbol. Here, we increase the
@@ -51,8 +51,16 @@ class TestStyle(unittest.TestCase):
         dirs_and_files = [
             'setup.py',
             'synbiohub_adapter/__init__.py',
+            'synbiohub_adapter/cache_query.py',
+            'synbiohub_adapter/upload_sbol/__init__.py',
+            'tests/DataGenerator.py',
+            'tests/SBHRun_Environment.py',
             'tests/__init__.py',
-            'tests/test_pycodestyle.py'
+            'tests/test_authentication.py',
+            'tests/test_fallback_cache.py',
+            'tests/test_pycodestyle.py',
+            'tests/test_sbh_submissions.py',
+            'tests/test_sbolquery.py'
         ]
         sg = pycodestyle.StyleGuide(quiet=QUIET,
                                     max_line_length=MAX_LINE_LENGTH,
@@ -62,46 +70,28 @@ class TestStyle(unittest.TestCase):
             self.assertEqual(report.total_errors, 0,
                              msg='New style violation introduced in previously clean file {}'.format(f))
 
-    def assert_clean_report(self, code, message):
-        """Verify that no erros of the given pycodestyle code exist in the
-        codebase.
-
-        """
-        dirs_and_files = ['.']
+    def assert_warning_count(self, code, count, message):
         sg = pycodestyle.StyleGuide(quiet=QUIET,
                                     max_line_length=MAX_LINE_LENGTH,
                                     exclude=EXCLUDE,
                                     select=[code])
-        report = sg.check_files(dirs_and_files)
-        self.assertEqual(report.total_errors, 0,
-                         msg=message)
+        report = sg.check_files('.')
+        message = 'Too many "{} {}" style errors. Expected {}, found {}'.format(code, message,
+                                                                                count, report.total_errors)
+        self.assertEqual(report.total_errors, count, msg=message)
 
-    def test_indentation(self):
-        self.assert_clean_report('E1', "Indentation style errors ('E1xx') exist")
+    def test_allowed_errors(self):
+        self.assert_warning_count('E501', 188, "line too long")
+        self.assert_warning_count('E722', 17, "do not use bare 'except'")
 
-    def test_whitespace(self):
-        self.assert_clean_report('E202', "whitespace before ')'")
-        self.assert_clean_report('E203', "whitespace before ':'")
-        self.assert_clean_report('E225', "missing whitespace around operator")
-        self.assert_clean_report('E226', "missing whitespace around arithmetic operator")
-        self.assert_clean_report('E251', "unexpected spaces around keyword / parameter equals")
-        self.assert_clean_report('E261', "at least two spaces before inline comment")
-        self.assert_clean_report('E271', "multiple spaces after keyword")
-
-    def test_blank_line(self):
-        self.assert_clean_report('E301', "expected 1 blank line, found 0")
-        self.assert_clean_report('E303', "too many blank lines (2)")
-        self.assert_clean_report('E305', "expected 2 blank lines after class or function definition, found 1")
-
-    def test_import(self):
-        self.assert_clean_report('E4', "Import style errors ('E4*') exist")
-
-    def test_statement(self):
-        self.assert_clean_report('E711', "comparison to None should be 'if cond is not None:'")
-        self.assert_clean_report('E713', "test for membership should be 'not in'")
-
-    def test_all_warnings(self):
-        self.assert_clean_report('W', "Style warnings ('W*') exists")
+    def test_disallowed_errors(self):
+        """All errors other than E501 and E722 should not appear in the code."""
+        sg = pycodestyle.StyleGuide(quiet=QUIET,
+                                    max_line_length=MAX_LINE_LENGTH,
+                                    exclude=EXCLUDE,
+                                    ignore=['E501', 'E722'])
+        report = sg.check_files('.')
+        self.assertEqual(report.total_errors, 0)
 
 
 if __name__ == '__main__':

--- a/tests/test_sparql_queries.py
+++ b/tests/test_sparql_queries.py
@@ -7,6 +7,7 @@ from getpass import getpass
 import sys
 import os
 
+
 class TestSBHQueries(unittest.TestCase):
 
     @classmethod
@@ -37,16 +38,17 @@ class TestSBHQueries(unittest.TestCase):
 
     # def test_query_collection_members(self):
     #   sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
-    #   members = sbh_query.query_collection_members([SD2Constants.YEAST_GATES_DESIGN_COLLECTION], ['https://hub.sd2e.org/user/sd2e/design/UWBF_7376/1', 'https://hub.sd2e.org/user/sd2e/design/pAN4036/1'])
-
+    #   members = sbh_query.query_collection_members([SD2Constants.YEAST_GATES_DESIGN_COLLECTION],
+    #                                                ['https://hub.sd2e.org/user/sd2e/design/UWBF_7376/1',
+    #                                                 'https://hub.sd2e.org/user/sd2e/design/pAN4036/1'])
     #   print(members)
 
     ###########
 
     # def test_query_collections(self):
     #   sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
-    #   members = sbh_query.query_collections([SD2Constants.SD2_DESIGN_COLLECTION, 'https://hub.sd2e.org/user/sd2e/design/google/1'])
-
+    #   members = sbh_query.query_collections([SD2Constants.SD2_DESIGN_COLLECTION,
+    #                                          'https://hub.sd2e.org/user/sd2e/design/google/1'])
     #   print(members)
 
     # Test control query methods \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
@@ -82,7 +84,10 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_controls = min_controls.difference(controls)
 
-        assert len(missing_controls) == 0,"Failed to retrieve {num} of minimum {mini} controls from SD2 program. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
+        msg = "Failed to retrieve {num} of minimum {mini} controls from SD2 program. Missing: {miss}"
+        assert len(missing_controls) == 0, msg.format(num=repr(len(min_controls) - len(controls)),
+                                                      mini=repr(len(min_controls)),
+                                                      miss='\n'.join(missing_controls))
 
     def test_query_design_set_controls(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -114,7 +119,10 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_controls = min_controls.difference(controls)
 
-        assert len(missing_controls) == 0,"Failed to retrieve {num} of minimum {mini} controls from Yeast Gates challenge problem. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
+        msg = "Failed to retrieve {num} of minimum {mini} controls from Yeast Gates challenge problem. Missing: {miss}"
+        assert len(missing_controls) == 0, msg.format(num=repr(len(min_controls) - len(controls)),
+                                                      mini=repr(len(min_controls)),
+                                                      miss='\n'.join(missing_controls))
 
     def test_query_design_fbead_controls(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -126,19 +134,27 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_controls = min_controls.difference(controls)
 
-        assert len(missing_controls) == 0,"Failed to retrieve {num} of minimum {mini} fluorescent bead controls from SD2 program. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
+        msg = "Failed to retrieve {num} of minimum {mini} fluorescent bead controls from SD2 program. Missing: {miss}"
+        assert len(missing_controls) == 0, msg.format(num=repr(len(min_controls) - len(controls)),
+                                                      mini=repr(len(min_controls)),
+                                                      miss='\n'.join(missing_controls))
 
     def test_query_design_set_fbead_controls(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
         sbh_query.login(self.user, self.password)
 
-        controls = set(sbh_query.query_design_set_fbead_controls(SD2Constants.YEAST_GATES_DESIGN_COLLECTION, pretty=True))
+        controls = set(sbh_query.query_design_set_fbead_controls(SD2Constants.YEAST_GATES_DESIGN_COLLECTION,
+                                                                 pretty=True))
 
         min_controls = {'https://hub.sd2e.org/user/sd2e/design/spherotech_rainbow_beads/1'}
 
         missing_controls = min_controls.difference(controls)
 
-        assert len(missing_controls) == 0,"Failed to retrieve {num} of minimum {mini} fluorescent bead controls from Yeast Gates challenge problem. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
+        msg = "Failed to retrieve {num} of minimum {mini} fluorescent bead"
+        msg += " controls from Yeast Gates challenge problem. Missing: {miss}"
+        assert len(missing_controls) == 0, msg.format(num=repr(len(min_controls) - len(controls)),
+                                                      mini=repr(len(min_controls)),
+                                                      miss='\n'.join(missing_controls))
 
     def test_query_design_fluorescein_controls(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -163,13 +179,17 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_controls = min_controls.difference(controls)
 
-        assert len(missing_controls) == 0,"Failed to retrieve {num} of minimum {mini} fluorescein controls from SD2 program. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
+        msg = "Failed to retrieve {num} of minimum {mini} fluorescein controls from SD2 program. Missing: {miss}"
+        assert len(missing_controls) == 0, msg.format(num=repr(len(min_controls) - len(controls)),
+                                                      mini=repr(len(min_controls)),
+                                                      miss='\n'.join(missing_controls))
 
     def test_query_design_set_fluorescein_controls(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
         sbh_query.login(self.user, self.password)
 
-        controls = set(sbh_query.query_design_set_fluorescein_controls(SD2Constants.YEAST_GATES_DESIGN_COLLECTION, pretty=True))
+        controls = set(sbh_query.query_design_set_fluorescein_controls(SD2Constants.YEAST_GATES_DESIGN_COLLECTION,
+                                                                       pretty=True))
 
         min_controls = {
             'https://hub.sd2e.org/user/sd2e/design/fluorescein_control_0_203125/1',
@@ -188,7 +208,11 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_controls = min_controls.difference(controls)
 
-        assert len(missing_controls) == 0,"Failed to retrieve {num} of minimum {mini} fluorescein controls from Yeast Gates challenge problem. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
+        msg = "Failed to retrieve {num} of minimum {mini} fluorescein controls from"
+        msg += " Yeast Gates challenge problem. Missing: {miss}"
+        assert len(missing_controls) == 0, msg.format(num=repr(len(min_controls) - len(controls)),
+                                                      mini=repr(len(min_controls)),
+                                                      miss='\n'.join(missing_controls))
 
     def test_query_design_ludox_controls(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -204,13 +228,17 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_controls = min_controls.difference(controls)
 
-        assert len(missing_controls) == 0,"Failed to retrieve {num} of minimum {mini} LUDOX controls from SD2 program. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
+        msg = "Failed to retrieve {num} of minimum {mini} LUDOX controls from SD2 program. Missing: {miss}"
+        assert len(missing_controls) == 0, msg.format(num=repr(len(min_controls) - len(controls)),
+                                                      mini=repr(len(min_controls)),
+                                                      miss='\n'.join(missing_controls))
 
     def test_query_design_set_ludox_controls(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
         sbh_query.login(self.user, self.password)
 
-        controls = set(sbh_query.query_design_set_ludox_controls(SD2Constants.YEAST_GATES_DESIGN_COLLECTION, pretty=True))
+        controls = set(sbh_query.query_design_set_ludox_controls(SD2Constants.YEAST_GATES_DESIGN_COLLECTION,
+                                                                 pretty=True))
 
         min_controls = {
             'https://hub.sd2e.org/user/sd2e/design/ludox_S40_control_100/1',
@@ -220,7 +248,10 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_controls = min_controls.difference(controls)
 
-        assert len(missing_controls) == 0,"Failed to retrieve {num} of minimum {mini} LUDOX controls from Yeast Gates challenge problem. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
+        msg = "Failed to retrieve {num} of minimum {mini} LUDOX controls from Yeast Gates challenge problem. Missing: {miss}"
+        assert len(missing_controls) == 0, msg.format(num=repr(len(min_controls) - len(controls)),
+                                                      mini=repr(len(min_controls)),
+                                                      miss='\n'.join(missing_controls))
 
     def test_query_design_water_controls(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -236,13 +267,17 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_controls = min_controls.difference(controls)
 
-        assert len(missing_controls) == 0,"Failed to retrieve {num} of minimum {mini} water controls from SD2 program. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
+        msg = "Failed to retrieve {num} of minimum {mini} water controls from SD2 program. Missing: {miss}"
+        assert len(missing_controls) == 0, msg.format(num=repr(len(min_controls) - len(controls)),
+                                                      mini=repr(len(min_controls)),
+                                                      miss='\n'.join(missing_controls))
 
     def test_query_design_set_water_controls(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
         sbh_query.login(self.user, self.password)
 
-        controls = set(sbh_query.query_design_set_water_controls(SD2Constants.YEAST_GATES_DESIGN_COLLECTION, pretty=True))
+        controls = set(sbh_query.query_design_set_water_controls(SD2Constants.YEAST_GATES_DESIGN_COLLECTION,
+                                                                 pretty=True))
 
         min_controls = {
             'https://hub.sd2e.org/user/sd2e/design/water_blank_300/1',
@@ -252,7 +287,10 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_controls = min_controls.difference(controls)
 
-        assert len(missing_controls) == 0,"Failed to retrieve {num} of minimum {mini} water controls from Yeast Gates challenge problem. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
+        msg = "Failed to retrieve {num} of minimum {mini} water controls from Yeast Gates challenge problem. Missing: {miss}"
+        assert len(missing_controls) == 0, msg.format(num=repr(len(min_controls) - len(controls)),
+                                                      mini=repr(len(min_controls)),
+                                                      miss='\n'.join(missing_controls))
 
     def test_query_experiment_controls(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -283,7 +321,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_controls = min_controls.difference(controls)
 
-        assert len(missing_controls) == 0,"Failed to retrieve {num} of minimum {mini} controls from SD2 experiments. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
+        assert len(missing_controls) == 0, "Failed to retrieve {num} of minimum {mini} controls from SD2 experiments. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
 
     def test_query_experiment_set_controls(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -314,7 +352,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_controls = min_controls.difference(controls)
 
-        assert len(missing_controls) == 0,"Failed to retrieve {num} of minimum {mini} controls from Yeast Gates experiments. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
+        assert len(missing_controls) == 0, "Failed to retrieve {num} of minimum {mini} controls from Yeast Gates experiments. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
 
     def test_query_single_experiment_controls(self):
         yeast_gates_experiment = 'https://hub.sd2e.org/user/sd2e/experiment/transcriptic_yeast_gates_q0_r1bfbfd7f8dn5/1'
@@ -326,7 +364,7 @@ class TestSBHQueries(unittest.TestCase):
 
         min_controls = 72
 
-        assert len(controls) >= min_controls,"Failed to retrieve {num} of {mini} control samples from Yeast Gates experiment {exp}.".format(num=repr(72 - len(controls)), mini=repr(min_controls), exp=yeast_gates_experiment.split('/')[-2])
+        assert len(controls) >= min_controls, "Failed to retrieve {num} of {mini} control samples from Yeast Gates experiment {exp}.".format(num=repr(72 - len(controls)), mini=repr(min_controls), exp=yeast_gates_experiment.split('/')[-2])
 
     # def test_query_experiment_fbead_controls(self):
     #   sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -365,7 +403,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_controls = min_controls.difference(controls)
 
-        assert len(missing_controls) == 0,"Failed to retrieve {num} of minimum {mini} fluorescein controls from SD2 experiments. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
+        assert len(missing_controls) == 0, "Failed to retrieve {num} of minimum {mini} fluorescein controls from SD2 experiments. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
 
     def test_query_experiment_set_fluorescein_controls(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -390,7 +428,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_controls = min_controls.difference(controls)
 
-        assert len(missing_controls) == 0,"Failed to retrieve {num} of minimum {mini} fluorescein controls from Yeast Gates experiments. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
+        assert len(missing_controls) == 0, "Failed to retrieve {num} of minimum {mini} fluorescein controls from Yeast Gates experiments. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
 
     def test_query_single_experiment_fluorescein_controls(self):
         yeast_gates_experiment = 'https://hub.sd2e.org/user/sd2e/experiment/transcriptic_yeast_gates_q0_r1bfbfd7f8dn5/1'
@@ -402,7 +440,7 @@ class TestSBHQueries(unittest.TestCase):
 
         min_controls = 48
 
-        assert len(controls) >= min_controls,"Failed to retrieve {num} of {mini} fluorescein control samples from Yeast Gates experiment {exp}.".format(num=repr(48 - len(controls)), mini=repr(min_controls), exp=yeast_gates_experiment.split('/')[-2])
+        assert len(controls) >= min_controls, "Failed to retrieve {num} of {mini} fluorescein control samples from Yeast Gates experiment {exp}.".format(num=repr(48 - len(controls)), mini=repr(min_controls), exp=yeast_gates_experiment.split('/')[-2])
 
     def test_query_experiment_ludox_controls(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -418,7 +456,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_controls = min_controls.difference(controls)
 
-        assert len(missing_controls) == 0,"Failed to retrieve {num} of minimum {mini} LUDOX controls from SD2 experiments. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
+        assert len(missing_controls) == 0, "Failed to retrieve {num} of minimum {mini} LUDOX controls from SD2 experiments. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
 
     def test_query_experiment_set_ludox_controls(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -434,7 +472,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_controls = min_controls.difference(controls)
 
-        assert len(missing_controls) == 0,"Failed to retrieve {num} of minimum {mini} LUDOX controls from Yeast Gates experiments. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
+        assert len(missing_controls) == 0, "Failed to retrieve {num} of minimum {mini} LUDOX controls from Yeast Gates experiments. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
 
     def test_query_single_experiment_ludox_controls(self):
         yeast_gates_experiment = 'https://hub.sd2e.org/user/sd2e/experiment/transcriptic_yeast_gates_q0_r1bfbfd7f8dn5/1'
@@ -446,7 +484,7 @@ class TestSBHQueries(unittest.TestCase):
 
         min_controls = 12
 
-        assert len(controls) >= min_controls,"Failed to retrieve {num} of {mini} LUDOX control samples from Yeast Gates experiment {exp}.".format(num=repr(12 - len(controls)), mini=repr(min_controls), exp=yeast_gates_experiment.split('/')[-2])
+        assert len(controls) >= min_controls, "Failed to retrieve {num} of {mini} LUDOX control samples from Yeast Gates experiment {exp}.".format(num=repr(12 - len(controls)), mini=repr(min_controls), exp=yeast_gates_experiment.split('/')[-2])
 
     def test_query_experiment_water_controls(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -462,7 +500,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_controls = min_controls.difference(controls)
 
-        assert len(missing_controls) == 0,"Failed to retrieve {num} of minimum {mini} water controls from SD2 experiments. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
+        assert len(missing_controls) == 0, "Failed to retrieve {num} of minimum {mini} water controls from SD2 experiments. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
 
     def test_query_experiment_set_water_controls(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -478,7 +516,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_controls = min_controls.difference(controls)
 
-        assert len(missing_controls) == 0,"Failed to retrieve {num} of minimum {mini} water controls from Yeast Gates experiments. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
+        assert len(missing_controls) == 0, "Failed to retrieve {num} of minimum {mini} water controls from Yeast Gates experiments. Missing: {miss}".format(num=repr(len(min_controls) - len(controls)), mini=repr(len(min_controls)), miss='\n'.join(missing_controls))
 
     def test_query_single_experiment_water_controls(self):
         yeast_gates_experiment = 'https://hub.sd2e.org/user/sd2e/experiment/transcriptic_yeast_gates_q0_r1bfbfd7f8dn5/1'
@@ -490,7 +528,7 @@ class TestSBHQueries(unittest.TestCase):
 
         min_controls = 12
 
-        assert len(controls) >= min_controls,"Failed to retrieve {num} of {mini} water control samples from Yeast Gates experiment {exp}.".format(num=repr(min_controls - len(controls)), mini=repr(min_controls), exp=yeast_gates_experiment.split('/')[-2])
+        assert len(controls) >= min_controls, "Failed to retrieve {num} of {mini} water control samples from Yeast Gates experiment {exp}.".format(num=repr(min_controls - len(controls)), mini=repr(min_controls), exp=yeast_gates_experiment.split('/')[-2])
 
     # Test gate query methods \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
@@ -506,7 +544,8 @@ class TestSBHQueries(unittest.TestCase):
     def test_query_gate_logic(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
         sbh_query.login(self.user, self.password)
-        actual_circuit = sbh_query.query_gate_logic(['https://hub.sd2e.org/user/sd2e/design/UWBF_16969/1'], pretty=True)
+        actual_circuit = sbh_query.query_gate_logic(['https://hub.sd2e.org/user/sd2e/design/UWBF_16969/1'],
+                                                    pretty=True)
         expected_circuit = [{'gate': 'https://hub.sd2e.org/user/sd2e/design/UWBF_16969/1',
                              'gate_type': 'http://www.openmath.org/cd/logic1#xor'}]
         assert expected_circuit == actual_circuit
@@ -587,13 +626,14 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_gates = min_gates.difference(gates)
 
-        assert len(missing_gates) == 0,"Failed to retrieve {num} of minimum {mini} logic gate strains from SD2 program. Missing: {miss}".format(num=repr(len(min_gates) - len(gates)), mini=repr(len(min_gates)), miss='\n'.join(missing_gates))
+        assert len(missing_gates) == 0, "Failed to retrieve {num} of minimum {mini} logic gate strains from SD2 program. Missing: {miss}".format(num=repr(len(min_gates) - len(gates)), mini=repr(len(min_gates)), miss='\n'.join(missing_gates))
 
     def test_query_design_set_gates(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
         sbh_query.login(self.user, self.password)
 
-        gates = set(sbh_query.query_design_set_gates(SD2Constants.YEAST_GATES_DESIGN_COLLECTION, with_role=False, pretty=True))
+        gates = set(sbh_query.query_design_set_gates(SD2Constants.YEAST_GATES_DESIGN_COLLECTION, with_role=False,
+                                                     pretty=True))
 
         min_gates = {
             'https://hub.sd2e.org/user/sd2e/design/UWBF_16967/1',
@@ -624,7 +664,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_gates = min_gates.difference(gates)
 
-        assert len(missing_gates) == 0,"Failed to retrieve {num} of minimum {mini} logic gate strains from Yeast Gates challenge problem. Missing: {miss}".format(num=repr(len(min_gates) - len(gates)), mini=repr(len(min_gates)), miss='\n'.join(missing_gates))
+        assert len(missing_gates) == 0, "Failed to retrieve {num} of minimum {mini} logic gate strains from Yeast Gates challenge problem. Missing: {miss}".format(num=repr(len(min_gates) - len(gates)), mini=repr(len(min_gates)), miss='\n'.join(missing_gates))
 
     def test_query_experiment_gates(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -661,13 +701,14 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_gates = min_gates.difference(gates)
 
-        assert len(missing_gates) == 0,"Failed to retrieve {num} of minimum {mini} logic gate strains from SD2 experiments. Missing: {miss}".format(num=repr(len(min_gates) - len(gates)), mini=repr(len(min_gates)), miss='\n'.join(missing_gates))
+        assert len(missing_gates) == 0, "Failed to retrieve {num} of minimum {mini} logic gate strains from SD2 experiments. Missing: {miss}".format(num=repr(len(min_gates) - len(gates)), mini=repr(len(min_gates)), miss='\n'.join(missing_gates))
 
     def test_query_experiment_set_gates(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
         sbh_query.login(self.user, self.password)
 
-        gates = set(sbh_query.query_experiment_set_gates(SD2Constants.YEAST_GATES_EXPERIMENT_COLLECTION, with_role=False))
+        gates = set(sbh_query.query_experiment_set_gates(SD2Constants.YEAST_GATES_EXPERIMENT_COLLECTION,
+                                                         with_role=False))
 
         min_gates = {
             'https://hub.sd2e.org/user/sd2e/design/UWBF_16967/1',
@@ -698,7 +739,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_gates = min_gates.difference(gates)
 
-        assert len(missing_gates) == 0,"Failed to retrieve {num} of minimum {mini} logic gate strains from Yeast Gates experiments. Missing: {miss}".format(num=repr(len(min_gates) - len(gates)), mini=repr(len(min_gates)), miss='\n'.join(missing_gates))
+        assert len(missing_gates) == 0, "Failed to retrieve {num} of minimum {mini} logic gate strains from Yeast Gates experiments. Missing: {miss}".format(num=repr(len(min_gates) - len(gates)), mini=repr(len(min_gates)), miss='\n'.join(missing_gates))
 
     ###########
 
@@ -805,7 +846,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_media = min_media.difference(media)
 
-        assert len(missing_media) == 0,"Failed to retrieve {num} of minimum {mini} growth media from SD2 program. Missing: {miss}".format(num=repr(len(min_media) - len(media)), mini=repr(len(min_media)), miss='\n'.join(missing_media))
+        assert len(missing_media) == 0, "Failed to retrieve {num} of minimum {mini} growth media from SD2 program. Missing: {miss}".format(num=repr(len(min_media) - len(media)), mini=repr(len(min_media)), miss='\n'.join(missing_media))
 
     def test_query_design_set_media(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -830,7 +871,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_media = min_media.difference(media)
 
-        assert len(missing_media) == 0,"Failed to retrieve {num} of minimum {mini} growth media from Yeast Gates challenge problem. Missing: {miss}".format(num=repr(len(min_media) - len(media)), mini=repr(len(min_media)), miss='\n'.join(missing_media))
+        assert len(missing_media) == 0, "Failed to retrieve {num} of minimum {mini} growth media from Yeast Gates challenge problem. Missing: {miss}".format(num=repr(len(min_media) - len(media)), mini=repr(len(min_media)), miss='\n'.join(missing_media))
 
     def test_query_experiment_media(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -852,7 +893,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_media = min_media.difference(media)
 
-        assert len(missing_media) == 0,"Failed to retrieve {num} of minimum {mini} growth media from SD2 experiments. Missing: {miss}".format(num=repr(len(min_media) - len(media)), mini=repr(len(min_media)), miss='\n'.join(missing_media))
+        assert len(missing_media) == 0, "Failed to retrieve {num} of minimum {mini} growth media from SD2 experiments. Missing: {miss}".format(num=repr(len(min_media) - len(media)), mini=repr(len(min_media)), miss='\n'.join(missing_media))
 
     def test_query_experiment_set_media(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -874,7 +915,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_media = min_media.difference(media)
 
-        assert len(missing_media) == 0,"Failed to retrieve {num} of minimum {mini} growth media from Yeast Gates experiments. Missing: {miss}".format(num=repr(len(min_media) - len(media)), mini=repr(len(min_media)), miss='\n'.join(missing_media))
+        assert len(missing_media) == 0, "Failed to retrieve {num} of minimum {mini} growth media from Yeast Gates experiments. Missing: {miss}".format(num=repr(len(min_media) - len(media)), mini=repr(len(min_media)), miss='\n'.join(missing_media))
 
     ###########
 
@@ -928,7 +969,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_plasmids = min_plasmids.difference(plasmids)
 
-        assert len(missing_plasmids) == 0,"Failed to retrieve {num} of minimum {mini} plasmids from SD2 program. Missing: {miss}".format(num=repr(len(min_plasmids) - len(plasmids)), mini=repr(len(min_plasmids)), miss='\n'.join(missing_plasmids))
+        assert len(missing_plasmids) == 0, "Failed to retrieve {num} of minimum {mini} plasmids from SD2 program. Missing: {miss}".format(num=repr(len(min_plasmids) - len(plasmids)), mini=repr(len(min_plasmids)), miss='\n'.join(missing_plasmids))
 
     def test_query_design_set_plasmids(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -966,7 +1007,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_plasmids = min_plasmids.difference(plasmids)
 
-        assert len(missing_plasmids) == 0,"Failed to retrieve {num} of minimum {mini} plasmids from Yeast Gates challenge problem. Missing: {miss}".format(num=repr(len(min_plasmids) - len(plasmids)), mini=repr(len(min_plasmids)), miss='\n'.join(missing_plasmids))
+        assert len(missing_plasmids) == 0, "Failed to retrieve {num} of minimum {mini} plasmids from Yeast Gates challenge problem. Missing: {miss}".format(num=repr(len(min_plasmids) - len(plasmids)), mini=repr(len(min_plasmids)), miss='\n'.join(missing_plasmids))
 
     def test_query_experiment_plasmids(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -1007,7 +1048,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_plasmids = min_plasmids.difference(plasmids)
 
-        assert len(missing_plasmids) == 0,"Failed to retrieve {num} of minimum {mini} plasmids from SD2 experiments. Missing: {miss}".format(num=repr(len(min_plasmids) - len(plasmids)), mini=repr(len(min_plasmids)), miss='\n'.join(missing_plasmids))
+        assert len(missing_plasmids) == 0, "Failed to retrieve {num} of minimum {mini} plasmids from SD2 experiments. Missing: {miss}".format(num=repr(len(min_plasmids) - len(plasmids)), mini=repr(len(min_plasmids)), miss='\n'.join(missing_plasmids))
 
     def test_query_experiment_set_plasmids(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -1044,7 +1085,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_plasmids = min_plasmids.difference(plasmids)
 
-        assert len(missing_plasmids) == 0,"Failed to retrieve {num} of minimum {mini} plasmids from Yeast Gates experiments. Missing: {miss}".format(num=repr(len(min_plasmids) - len(plasmids)), mini=repr(len(min_plasmids)), miss='\n'.join(missing_plasmids))
+        assert len(missing_plasmids) == 0, "Failed to retrieve {num} of minimum {mini} plasmids from Yeast Gates experiments. Missing: {miss}".format(num=repr(len(min_plasmids) - len(plasmids)), mini=repr(len(min_plasmids)), miss='\n'.join(missing_plasmids))
 
     ############
 
@@ -1077,7 +1118,8 @@ class TestSBHQueries(unittest.TestCase):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
         sbh_query.login(self.user, self.password)
 
-        primers = set(sbh_query.query_design_primers(with_sequence=False, pretty=True, downstream_gene=downstream_gene))
+        primers = set(sbh_query.query_design_primers(with_sequence=False, pretty=True,
+                                                     downstream_gene=downstream_gene))
 
         min_primers = {
             'https://hub.sd2e.org/user/sd2e/design/UCSB_PNNL_Output_Primer_4232/1',
@@ -1092,7 +1134,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_primers = min_primers.difference(primers)
 
-        assert len(missing_primers) == 0,"Failed to retrieve {num} of minimum {mini} primers with downstream gene {dg} from SD2 program. Missing: {miss}".format(num=repr(len(min_primers) - len(primers)), mini=repr(len(min_primers)), dg=downstream_gene, miss='\n'.join(missing_primers))
+        assert len(missing_primers) == 0, "Failed to retrieve {num} of minimum {mini} primers with downstream gene {dg} from SD2 program. Missing: {miss}".format(num=repr(len(min_primers) - len(primers)), mini=repr(len(min_primers)), dg=downstream_gene, miss='\n'.join(missing_primers))
 
     def test_query_design_set_primers(self):
         downstream_gene = 'dnaA'
@@ -1100,7 +1142,10 @@ class TestSBHQueries(unittest.TestCase):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
         sbh_query.login(self.user, self.password)
 
-        primers = set(sbh_query.query_design_set_primers(SD2Constants.NOVEL_CHASSIS_DESIGN_COLLECTION, with_sequence=False, pretty=True, downstream_gene=downstream_gene))
+        primers = set(sbh_query.query_design_set_primers(SD2Constants.NOVEL_CHASSIS_DESIGN_COLLECTION,
+                                                         with_sequence=False,
+                                                         pretty=True,
+                                                         downstream_gene=downstream_gene))
 
         min_primers = {
             'https://hub.sd2e.org/user/sd2e/design/UCSB_PNNL_Output_Primer_4232/1',
@@ -1115,7 +1160,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_primers = min_primers.difference(primers)
 
-        assert len(missing_primers) == 0,"Failed to retrieve {num} of minimum {mini} primers with downstream gene {dg} from Novel Chassis challenge problem. Missing: {miss}".format(num=repr(len(min_primers) - len(primers)), mini=repr(len(min_primers)), dg=downstream_gene, miss='\n'.join(missing_primers))
+        assert len(missing_primers) == 0, "Failed to retrieve {num} of minimum {mini} primers with downstream gene {dg} from Novel Chassis challenge problem. Missing: {miss}".format(num=repr(len(min_primers) - len(primers)), mini=repr(len(min_primers)), dg=downstream_gene, miss='\n'.join(missing_primers))
 
     # # Test riboswitch query methods \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
@@ -1127,17 +1172,18 @@ class TestSBHQueries(unittest.TestCase):
 
         min_riboswitches = 193
 
-        assert len(riboswitches) >= min_riboswitches,"Failed to retrieve {num} of minimum {mini} riboswitches from SD2 program.".format(num=repr(min_riboswitches - len(riboswitches)), mini=repr(min_riboswitches))
+        assert len(riboswitches) >= min_riboswitches, "Failed to retrieve {num} of minimum {mini} riboswitches from SD2 program.".format(num=repr(min_riboswitches - len(riboswitches)), mini=repr(min_riboswitches))
 
     def test_query_design_set_riboswitches(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
         sbh_query.login(self.user, self.password)
 
-        riboswitches = sbh_query.query_design_set_riboswitches(SD2Constants.RIBOSWITCHES_DESIGN_COLLECTION, pretty=True)
+        riboswitches = sbh_query.query_design_set_riboswitches(SD2Constants.RIBOSWITCHES_DESIGN_COLLECTION,
+                                                               pretty=True)
 
         min_riboswitches = 193
 
-        assert len(riboswitches) >= min_riboswitches,"Failed to retrieve {num} of minimum {mini} riboswitches from Riboswitches challenge problem.".format(num=repr(min_riboswitches - len(riboswitches)), mini=repr(min_riboswitches))
+        assert len(riboswitches) >= min_riboswitches, "Failed to retrieve {num} of minimum {mini} riboswitches from Riboswitches challenge problem.".format(num=repr(min_riboswitches - len(riboswitches)), mini=repr(min_riboswitches))
 
     # # Test strain query methods \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
@@ -1153,7 +1199,9 @@ class TestSBHQueries(unittest.TestCase):
 
         min_strains = 51
 
-        assert len(strains) >= min_strains,"Failed to retrieve {num} of minimum {mini} strains from SD2 program.".format(num=repr(min_strains - len(strains)), mini=repr(min_strains))
+        msg = "Failed to retrieve {num} of minimum {mini} strains from SD2 program."
+        assert len(strains) >= min_strains, msg.format(num=repr(min_strains - len(strains)),
+                                                       mini=repr(min_strains))
 
     def test_query_design_set_strains(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -1191,7 +1239,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_strains = min_strains.difference(strains)
 
-        assert len(missing_strains) == 0,"Failed to retrieve {num} of minimum {mini} strains from Yeast Gates challenge problem. Missing: {miss}".format(num=repr(len(min_strains) - len(strains)), mini=repr(len(min_strains)), miss='\n'.join(missing_strains))
+        assert len(missing_strains) == 0, "Failed to retrieve {num} of minimum {mini} strains from Yeast Gates challenge problem. Missing: {miss}".format(num=repr(len(min_strains) - len(strains)), mini=repr(len(min_strains)), miss='\n'.join(missing_strains))
 
     def test_query_experiment_strains(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -1228,7 +1276,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_strains = min_strains.difference(strains)
 
-        assert len(missing_strains) == 0,"Failed to retrieve {num} of minimum {mini} strains from SD2 experiments. Missing: {miss}".format(num=repr(len(min_strains) - len(strains)), mini=repr(len(min_strains)), miss='\n'.join(missing_strains))
+        assert len(missing_strains) == 0, "Failed to retrieve {num} of minimum {mini} strains from SD2 experiments. Missing: {miss}".format(num=repr(len(min_strains) - len(strains)), mini=repr(len(min_strains)), miss='\n'.join(missing_strains))
 
     def test_query_experiment_set_strains(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -1265,7 +1313,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_strains = min_strains.difference(strains)
 
-        assert len(missing_strains) == 0,"Failed to retrieve {num} of minimum {mini} strains from Yeast Gates experiments. Missing: {miss}".format(num=repr(len(min_strains) - len(strains)), mini=repr(len(min_strains)), miss='\n'.join(missing_strains))
+        assert len(missing_strains) == 0, "Failed to retrieve {num} of minimum {mini} strains from Yeast Gates experiments. Missing: {miss}".format(num=repr(len(min_strains) - len(strains)), mini=repr(len(min_strains)), miss='\n'.join(missing_strains))
 
     # def test_query_single_experiment_strains(self):
     #   rule_30_experiment = 'https://hub.sd2e.org/user/sd2e/experiment/transcriptic_rule_30_q0_1_09242017/1'
@@ -1324,7 +1372,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_design_sets = min_design_sets.difference(design_sets)
 
-        assert len(missing_design_sets) == 0,"Failed to retrieve {num} of minimum {mini} design collections from SD2 program. Missing: {miss}".format(num=repr(len(min_design_sets) - len(design_sets)), mini=repr(len(min_design_sets)), miss='\n'.join(missing_design_sets))
+        assert len(missing_design_sets) == 0, "Failed to retrieve {num} of minimum {mini} design collections from SD2 program. Missing: {miss}".format(num=repr(len(min_design_sets) - len(design_sets)), mini=repr(len(min_design_sets)), miss='\n'.join(missing_design_sets))
 
     def test_query_experiment_sets(self):
         sbh_query = SynBioHubQuery(SD2Constants.SD2_SERVER)
@@ -1341,7 +1389,7 @@ class TestSBHQueries(unittest.TestCase):
 
         missing_exp_sets = min_exp_sets.difference(exp_sets)
 
-        assert len(missing_exp_sets) == 0,"Failed to retrieve {num} of minimum {mini} experiment collections from SD2 program. Missing: {miss}".format(num=repr(len(min_exp_sets) - len(exp_sets)), mini=repr(len(min_exp_sets)), miss='\n'.join(missing_exp_sets))
+        assert len(missing_exp_sets) == 0, "Failed to retrieve {num} of minimum {mini} experiment collections from SD2 program. Missing: {miss}".format(num=repr(len(min_exp_sets) - len(exp_sets)), mini=repr(len(min_exp_sets)), miss='\n'.join(missing_exp_sets))
 
     def test_query_experiment_set_size(self):
         experiment_set = SD2Constants.YEAST_GATES_EXPERIMENT_COLLECTION
@@ -1353,7 +1401,7 @@ class TestSBHQueries(unittest.TestCase):
 
         min_exp_set_size = 46
 
-        assert exp_set_size >= min_exp_set_size,"Failed to retrieve {num} of minimum {mini} experiments from collection with URI <{es}>.".format(num=repr(min_exp_set_size - exp_set_size), mini=repr(min_exp_set_size), es=experiment_set)
+        assert exp_set_size >= min_exp_set_size, "Failed to retrieve {num} of minimum {mini} experiments from collection with URI <{es}>.".format(num=repr(min_exp_set_size - exp_set_size), mini=repr(min_exp_set_size), es=experiment_set)
 
     # # Test attachment retrieval methods \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 


### PR DESCRIPTION
Reduce style errors from 365 to 205. Reduce style error types to E501
line too long and E722 do not use bare 'except'. Add tests to ensure
that only those two style error types are allowed.