### PR TITLE
Handle string arguments instead of lists

### DIFF
--- a/synbiohub_adapter/SynBioHubUtil.py
+++ b/synbiohub_adapter/SynBioHubUtil.py
@@ -481,7 +481,8 @@ class SBOLQuery():
 
         if len(other_entity_labels) > 0:
             target_labels.extend(other_entity_labels)
-        target_labels.append(entity_label)
+        if entity_label not in target_labels:
+            target_labels.append(entity_label)
 
         sub_entity_pattern = self.construct_entity_pattern(types=sub_types, roles=sub_roles, all_types=all_sub_types,
                                                            entity_label=sub_entity_label, type_label='sub_type',
@@ -782,25 +783,19 @@ class SBOLQuery():
         return unit_uris
 
     def serialize_options(self, options):
-        serial_options = []
-        for opt in options:
-            serial_options.append(''.join(['( <', opt, '> ) ']))
-
-        return ''.join(serial_options)[:-1]
+        if isinstance(options, (str, bytes)):
+            options = [options]
+        return ' '.join(['( <' + opt + '> )' for opt in options])
 
     def serialize_literal_options(self, options):
-        serial_options = []
-        for opt in options:
-            serial_options.append(''.join(['( "', opt, '" ) ']))
-
-        return ''.join(serial_options)[:-1]
+        if isinstance(options, (str, bytes)):
+            options = [options]
+        return ' '.join(['( "' + opt + '" )' for opt in options])
 
     def serialize_objects(self, objects):
-        serial_objects = []
-        for obj in objects:
-            serial_objects.append(''.join(['<', obj, '>, ']))
-
-        return ''.join(serial_objects)[:-2]
+        if isinstance(objects, (str, bytes)):
+            objects = [objects]
+        return ', '.join(['<' + obj + '>' for obj in objects])
 
 
 def loadSBOLFile(sbolFile):

--- a/tests/test_pycodestyle.py
+++ b/tests/test_pycodestyle.py
@@ -59,7 +59,8 @@ class TestStyle(unittest.TestCase):
             'tests/test_authentication.py',
             'tests/test_fallback_cache.py',
             'tests/test_pycodestyle.py',
-            'tests/test_sbh_submissions.py'
+            'tests/test_sbh_submissions.py',
+            'tests/test_sbolquery.py'
         ]
         sg = pycodestyle.StyleGuide(quiet=QUIET,
                                     max_line_length=MAX_LINE_LENGTH,

--- a/tests/test_sbolquery.py
+++ b/tests/test_sbolquery.py
@@ -1,0 +1,64 @@
+import getpass
+import os
+import unittest
+
+import synbiohub_adapter as sbha
+
+
+class TestStyle(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        self.user = 'sd2e'
+        if 'SBH_PASSWORD' in os.environ.keys():
+            self.password = os.environ['SBH_PASSWORD']
+        else:
+            self.password = getpass.getpass()
+        # Use the staging server so we don't bother the production server
+        self.sbol_query = sbha.SBOLQuery(sbha.SD2Constants.SD2_STAGING_SERVER,
+                                         spoofed_url=sbha.SD2Constants.SD2_SERVER)
+        self.sbol_query.login(self.user, self.password)
+
+    def test_serialize_options(self):
+        # pairs of input and expected results
+        cases = [
+            ([], ''),
+            (['alpha'], '( <alpha> )'),
+            (['alpha', 'beta'], '( <alpha> ) ( <beta> )'),
+            ('alpha', '( <alpha> )')
+        ]
+        for arg, expected in cases:
+            self.assertEqual(self.sbol_query.serialize_options(arg), expected)
+        with self.assertRaises(TypeError) as _:
+            self.sbol_query.serialize_options(None)
+
+    def test_serialize_literal_options(self):
+        # pairs of input and expected results
+        cases = [
+            ([], ''),
+            (['alpha'], '( "alpha" )'),
+            (['alpha', 'beta'], '( "alpha" ) ( "beta" )'),
+            ('alpha', '( "alpha" )')
+        ]
+        for arg, expected in cases:
+            self.assertEqual(self.sbol_query.serialize_literal_options(arg), expected)
+        with self.assertRaises(TypeError) as _:
+            self.sbol_query.serialize_literal_options(None)
+
+    def test_serialize_objects(self):
+        # pairs of input and expected results
+        cases = [
+            ([], ''),
+            (['alpha'], '<alpha>'),
+            (['alpha', 'beta'], '<alpha>, <beta>'),
+            ('alpha', '<alpha>')
+        ]
+        for arg, expected in cases:
+            self.assertEqual(self.sbol_query.serialize_objects(arg), expected)
+        with self.assertRaises(TypeError) as _:
+            self.sbol_query.serialize_objects(None)
+
+    def test_query_collections(self):
+        collections = self.sbol_query.query_collections([sbha.SD2Constants.YEAST_GATES_DESIGN_COLLECTION])
+        collections2 = self.sbol_query.query_collections(sbha.SD2Constants.YEAST_GATES_DESIGN_COLLECTION)
+        self.assertEqual(collections, collections2)


### PR DESCRIPTION
For some methods, it is confusing to pass a list of one
element. Passing the element alone causes a large stacktrace with
confusing errors. Modify the underlying routines to handle either
lists or strings gracefully.

Additionally, fix up query_collections() to handle a string instead of
a list when generating the variables in the query.

Add unit tests for the underlying routines and for query_collections.

Fixes #103 