### PR TITLE
Remove expectedFailure annotation

### DIFF
--- a/tests/test_sbh_submissions.py
+++ b/tests/test_sbh_submissions.py
@@ -134,7 +134,6 @@ class TestSBHSubmissions(unittest.TestCase):
         self.assertIn(member_identity1, query_result[collection_identity])
         self.assertIn(member_identity2, query_result[collection_identity])
 
-    @unittest.expectedFailure
     def test_submit_to_sub_collection(self):
         sbh = SynBioHub(SD2Constants.SD2_STAGING_SERVER, self.user, self.password,
                         SD2Constants.SD2_STAGING_SERVER + '/sparql', SD2Constants.SD2_SERVER)


### PR DESCRIPTION
Mark a formerly failing test as expected to succeeed because it is.